### PR TITLE
Fix Firebase rewrites to route to index.html

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,7 +9,7 @@
     "rewrites": [
       {
         "source": "**",
-        "destination": "/"
+        "destination": "/index.html"
       }
     ]
   }


### PR DESCRIPTION
https://dreamerscholars.web.app/scholarships returns a 404. It turns out that rewriting to `/` is not the same as rewriting to `index.html`