### PR TITLE
Run audit check only when yarn.lock is modified and on merges to main

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,26 @@
+# Workflow for validating package dependencies
+name: Validation
+
+# Only run on merges to main and on pull requests that touch yarn.lock
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    paths: ['yarn.lock']
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+      - name: Setup node.js
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+          check-latest: true
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Audit for vulnerabilities
+        run: yarn audit

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,23 +8,8 @@ on:
   pull_request:
     branches: [ main ]
 
-# This workflow is made up of four jobs: audit, build, lint, and test
+# This workflow is made up of three jobs: build, lint, and test
 jobs:
-  audit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v2
-      - name: Setup node.js
-        uses: actions/setup-node@v2-beta
-        with:
-          node-version: '12'
-          check-latest: true
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: Audit for vulnerabilities
-        run: yarn audit
-
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It's a bit frustrating to see an audit check fail but no fix available when you haven't changed the dependencies. Now that we have [Dependabot updates](https://github.com/beyondhb1079/s4us/network/updates) set up, we can rely on it to create PRs to update dependencies. So instead let's leave this check for commits to `main` and PRs that touch `yarn.lock`