### PR TITLE
Run ossar-analysis.yml on PRs and pushes to main only

### DIFF
--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -5,7 +5,9 @@ name: OSSAR
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   OSSAR-Scan:


### PR DESCRIPTION
Otherwise it ends up running on any push and on any pull request event, which leads to duplicate runs when updating a pull request and unnecessary runs for feature branches not yet ready for review.