### PR TITLE
Create Firebase context provider that uses emulators on local development

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -15,6 +15,9 @@
     },
     "ui": {
       "enabled": true
+    },
+    "auth": {
+      "port": 9099
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.0.3"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "firebase emulators:exec --only firestore \"react-scripts start\"",
     "build": "react-scripts build",
     "test": "firebase emulators:exec --only firestore \"react-scripts test --verbose\"",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "typescript": "^4.0.3"
   },
   "scripts": {
-    "start": "firebase emulators:exec --ui \"react-scripts start\"",
+    "start": "firebase emulators:exec --ui 'react-scripts start'",
     "build": "react-scripts build",
-    "test": "firebase emulators:exec --only firestore \"react-scripts test --verbose\"",
+    "test": "firebase emulators:exec --only firestore 'react-scripts test --verbose'",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "eject": "react-scripts eject"
   },
@@ -148,7 +148,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "yarn lint && firebase emulators:exec --only firestore \"react-scripts test --watchAll=false\""
+      "pre-push": "yarn lint && firebase emulators:exec --only firestore 'react-scripts test --watchAll=false'"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.0.3"
   },
   "scripts": {
-    "start": "firebase emulators:exec --only firestore \"react-scripts start\"",
+    "start": "firebase emulators:exec --ui \"react-scripts start\"",
     "build": "react-scripts build",
     "test": "firebase emulators:exec --only firestore \"react-scripts test --verbose\"",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,7 @@
 import './App.css';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
-import firebase from 'firebase';
-import React, { createContext } from 'react';
+import React from 'react';
 import { CssBaseline, ThemeProvider } from '@material-ui/core';
-import FirebaseConfig from './config/FirebaseConfig';
 import Footer from './components/Footer';
 import Header from './components/Header';
 import Home from './pages/Home';
@@ -13,32 +11,9 @@ import About from './pages/About';
 import Contact from './pages/Contact';
 import ScholarshipForm from './pages/ScholarshipForm';
 import theme from './theme';
-
-const FirebaseContext = createContext(null);
-
-function FirebaseProvider({ children }) {
-  if (firebase.apps.length === 0) {
-    switch (process.env.NODE_ENV) {
-      case 'production':
-        firebase.initializeApp(FirebaseConfig);
-        break;
-      // TODO: consider staging environment
-      case 'development':
-      case 'test':
-      default:
-        firebase.initializeApp(FirebaseConfig);
-        firebase.firestore().settings({ host: 'localhost:8080', ssl: false });
-      // TODO: do we want test environment too?
-    }
-  }
-  return (
-    <FirebaseContext.Provider value={true}>{children}</FirebaseContext.Provider>
-  );
-}
+import FirebaseProvider from './lib/FirebaseProvider';
 
 function App() {
-  console.log(JSON.stringify(process.env));
-
   return (
     <FirebaseProvider>
       <ThemeProvider theme={theme}>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import './App.css';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import firebase from 'firebase';
-import React from 'react';
+import React, { createContext } from 'react';
 import { CssBaseline, ThemeProvider } from '@material-ui/core';
 import FirebaseConfig from './config/FirebaseConfig';
 import Footer from './components/Footer';
@@ -14,25 +14,49 @@ import Contact from './pages/Contact';
 import ScholarshipForm from './pages/ScholarshipForm';
 import theme from './theme';
 
+const FirebaseContext = createContext(null);
+
+function FirebaseProvider({ children }) {
+  if (firebase.apps.length === 0) {
+    switch (process.env.NODE_ENV) {
+      case 'production':
+        firebase.initializeApp(FirebaseConfig);
+        break;
+      // TODO: consider staging environment
+      case 'development':
+      case 'test':
+      default:
+        firebase.initializeApp(FirebaseConfig);
+        firebase.firestore().settings({ host: 'localhost:8080', ssl: false });
+      // TODO: do we want test environment too?
+    }
+  }
+  return (
+    <FirebaseContext.Provider value={true}>{children}</FirebaseContext.Provider>
+  );
+}
+
 function App() {
-  firebase.initializeApp(FirebaseConfig);
+  console.log(JSON.stringify(process.env));
 
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <Router>
-        <Header />
-        <Switch>
-          <Route path="/scholarships/new" component={ScholarshipForm} />
-          <Route path="/scholarships/:id" component={ScholarshipDetails} />
-          <Route path="/scholarships" component={Scholarships} />
-          <Route path="/about" component={About} />
-          <Route path="/contact" component={Contact} />
-          <Route path="/" component={Home} />
-        </Switch>
-        <Footer />
-      </Router>
-    </ThemeProvider>
+    <FirebaseProvider>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Router>
+          <Header />
+          <Switch>
+            <Route path="/scholarships/new" component={ScholarshipForm} />
+            <Route path="/scholarships/:id" component={ScholarshipDetails} />
+            <Route path="/scholarships" component={Scholarships} />
+            <Route path="/about" component={About} />
+            <Route path="/contact" component={Contact} />
+            <Route path="/" component={Home} />
+          </Switch>
+          <Footer />
+        </Router>
+      </ThemeProvider>
+    </FirebaseProvider>
   );
 }
 

--- a/src/components/Header.test.jsx
+++ b/src/components/Header.test.jsx
@@ -3,9 +3,8 @@ import { MemoryRouter } from 'react-router-dom';
 import firebase from 'firebase';
 import { render } from '@testing-library/react';
 import Header from './Header';
-import FirebaseConfig from '../config/FirebaseConfig';
 
-firebase.initializeApp(FirebaseConfig);
+firebase.initializeApp({ apiKey: 'fake-api-key' });
 
 test('does not render alert by default', () => {
   delete window.location;

--- a/src/config/FirebaseConfig.jsx
+++ b/src/config/FirebaseConfig.jsx
@@ -1,7 +1,0 @@
-export const firebaseConfig = {
-  apiKey: 'AIzaSyAXDqsWK4quNVaf9-YV2e28NsxkfA9rzJA',
-  authDomain: 'dreamerscholars.firebaseapp.com',
-  projectId: 'dreamerscholars',
-};
-
-export default firebaseConfig;

--- a/src/lib/FirebaseProvider.tsx
+++ b/src/lib/FirebaseProvider.tsx
@@ -1,0 +1,37 @@
+import React, { createContext } from 'react';
+import firebase from 'firebase';
+
+const FirebaseContext = createContext(null);
+
+const config = {
+  // TODO (issues/213): Configure a separate staging project.
+  // These values should really be read from the environment.
+  apiKey: 'AIzaSyAXDqsWK4quNVaf9-YV2e28NsxkfA9rzJA',
+  authDomain: 'dreamerscholars.firebaseapp.com',
+  projectId: 'dreamerscholars',
+};
+
+export default function FirebaseProvider(props: {
+  children: JSX.Element;
+}): JSX.Element {
+  const { children } = props;
+
+  if (firebase.apps.length === 0) {
+    // eslint-disable-next-line no-console
+    console.log(`Environment: ${JSON.stringify(process.env.NODE_ENV)}`);
+    if (process.env.NODE_ENV === 'production') {
+      firebase.initializeApp(config);
+    } else {
+      firebase.initializeApp({
+        // TODO (issues/214): Setup auth emulator once supported
+        apiKey: 'AIzaSyAXDqsWK4quNVaf9-YV2e28NsxkfA9rzJA',
+        authDomain: 'dreamerscholars.firebaseapp.com',
+        projectId: 'dreamerscholars-dev',
+      });
+      firebase.firestore().settings({ host: 'localhost:8080', ssl: false });
+    }
+  }
+  return (
+    <FirebaseContext.Provider value={null}>{children}</FirebaseContext.Provider>
+  );
+}


### PR DESCRIPTION
## Description
- Create a [Context](https://en.reactjs.org/docs/context.html) that initializes the Firebase app once.
- In the Firebase context provider, connect to the Firestore emulator instead when in development.
- Make `yarn start` surround `react-scripts start` with setup of Firebase emulators and the UI (located at http://localhost:4000 when running `yarn start`)

## Motivation and Context

Fixes #212, which solves two issues:
- Touching Firestore production data while developing locally iteratively
- Initializing Firebase app just once. The way we had it before it could technically be initialized again if the `<App>` component were re-rendered.

## How Has This Been Tested?
Locally it runs the Firestore emulator, which shows no scholarship data. But on the [Render preview](https://s4us-pr-215.onrender.com/scholarships) it shows the production data.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] User visible change (users will notice UI or functional changes)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
