### PR TITLE
Autoapprove all dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-autoapprove.yml
+++ b/.github/workflows/dependabot-autoapprove.yml
@@ -1,4 +1,4 @@
-name: 'Dependabot Automerge - Action'
+name: 'Dependabot Autoapprove - Action'
 
 on:
   pull_request:
@@ -9,17 +9,11 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
-    name: Automerge changes if yarn.lock
+    name: Autoapprove changes
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2
-      - name: Check for package.json changes
-        run: |
-          if git diff-tree --name-only --exit-code -r ${{ github.sha }} package.json; then
-            echo "::set-env name=lock_only_change::true"
-          fi
       - name: Automerge
-        if: ${{ env.lock_only_change == 'true' }}
         uses: actions/github-script@0.2.0
         with:
           script: |


### PR DESCRIPTION
Context: 
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This is why the **Dependabot Automerge** checks are failing. I've simplified the logic to just auto approve dependabot PRs. They won't be able to go in without passing the checks first anyways.