### PR TITLE
Pass scholarship state between list and detail pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ package-lock.json
 # production
 /build
 
+# temporary
+/tmp
+
 # misc
 .DS_Store
 .env.local

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "eslint-plugin-react": "^7.21.1",
     "eslint-plugin-react-hooks": "^4.1.2",
     "firebase-tools": "^8.12.1",
+    "history": "^5.0.0",
     "husky": "^4.3.0",
     "lint-staged": "^10.4.2",
     "mutation-observer": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "yup": "^0.31.1"
   },
   "scripts": {
-    "start": "firebase emulators:exec --ui 'react-scripts start'",
+    "start": "firebase emulators:exec --import=tmp/ --export-on-exit --ui 'react-scripts start'",
     "build": "react-scripts build",
     "test": "firebase emulators:exec --only firestore 'react-scripts test --verbose'",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",

--- a/src/components/ScholarshipList.jsx
+++ b/src/components/ScholarshipList.jsx
@@ -55,7 +55,9 @@ function ScholarshipList({ scholarships }) {
     if (navigator.share) {
       navigator
         .share({ title, url, text })
+        // eslint-disable-next-line no-console
         .then(() => console.log('Thanks for sharing!'))
+        // eslint-disable-next-line no-console
         .catch(console.error);
     } else {
       setShareSiteLink(url);
@@ -106,6 +108,7 @@ function ScholarshipList({ scholarships }) {
                 <IconButton
                   aria-label="add to bookmarks"
                   color="primary"
+                  // eslint-disable-next-line no-alert
                   onClick={() => alert('This feature is under construction')}>
                   <BookmarkBorderIcon />
                 </IconButton>

--- a/src/components/ScholarshipList.jsx
+++ b/src/components/ScholarshipList.jsx
@@ -67,8 +67,7 @@ function ScholarshipList({ scholarships }) {
   };
   return (
     <Grid container spacing={3}>
-      {scholarships.map((scholarship) => {
-        const { id, data } = scholarship;
+      {scholarships.map(({ id, data }) => {
         return (
           <Grid item xs={12} key={id}>
             <Card variant="outlined">
@@ -76,7 +75,7 @@ function ScholarshipList({ scholarships }) {
                 component={Link}
                 to={{
                   pathname: `/scholarships/${id}`,
-                  state: { scholarship },
+                  state: { scholarship: { id, data } },
                 }}>
                 <CardHeader
                   title={data.name}

--- a/src/components/ScholarshipList.jsx
+++ b/src/components/ScholarshipList.jsx
@@ -65,53 +65,61 @@ function ScholarshipList({ scholarships }) {
   };
   return (
     <Grid container spacing={3}>
-      {scholarships.map(({ id, data }) => (
-        <Grid item xs={12} key={id}>
-          <Card variant="outlined">
-            <CardActionArea component={Link} to={`/scholarships/${id}`}>
-              <CardHeader
-                title={data.name}
-                subheader={data.amount.toString()}
-              />
-              <CardContent className={classes.content}>
-                <Typography gutterBottom variant="body1">
-                  Deadline:{' '}
-                  <Typography component="span" color="primary">
-                    {data.deadline.toLocaleDateString()}
+      {scholarships.map((scholarship) => {
+        const { id, data } = scholarship;
+        return (
+          <Grid item xs={12} key={id}>
+            <Card variant="outlined">
+              <CardActionArea
+                component={Link}
+                to={{
+                  pathname: `/scholarships/${id}`,
+                  state: { scholarship },
+                }}>
+                <CardHeader
+                  title={data.name}
+                  subheader={data.amount.toString()}
+                />
+                <CardContent className={classes.content}>
+                  <Typography gutterBottom variant="body1">
+                    Deadline:{' '}
+                    <Typography component="span" color="primary">
+                      {data.deadline.toLocaleDateString()}
+                    </Typography>
                   </Typography>
-                </Typography>
-                <Typography
-                  variant="body1"
-                  color="textSecondary"
-                  className={classes.description}>
-                  {data.description}
-                </Typography>
-              </CardContent>
-            </CardActionArea>
-            <CardActions className={classes.actions}>
-              <Button
-                component={MuiLink}
-                href={data.website}
-                color="primary"
-                variant="contained">
-                Apply
-              </Button>
-              <IconButton
-                aria-label="add to bookmarks"
-                color="primary"
-                onClick={() => alert('This feature is under construction')}>
-                <BookmarkBorderIcon />
-              </IconButton>
-              <IconButton
-                aria-label="share"
-                color="primary"
-                onClick={shareFn(id, data)}>
-                <ShareIcon />
-              </IconButton>
-            </CardActions>
-          </Card>
-        </Grid>
-      ))}
+                  <Typography
+                    variant="body1"
+                    color="textSecondary"
+                    className={classes.description}>
+                    {data.description}
+                  </Typography>
+                </CardContent>
+              </CardActionArea>
+              <CardActions className={classes.actions}>
+                <Button
+                  component={MuiLink}
+                  href={data.website}
+                  color="primary"
+                  variant="contained">
+                  Apply
+                </Button>
+                <IconButton
+                  aria-label="add to bookmarks"
+                  color="primary"
+                  onClick={() => alert('This feature is under construction')}>
+                  <BookmarkBorderIcon />
+                </IconButton>
+                <IconButton
+                  aria-label="share"
+                  color="primary"
+                  onClick={shareFn(id, data)}>
+                  <ShareIcon />
+                </IconButton>
+              </CardActions>
+            </Card>
+          </Grid>
+        );
+      })}
       <ShareDialog
         open={shareDialogOpen}
         onClose={closeShareDialog}

--- a/src/components/ScholarshipList.jsx
+++ b/src/components/ScholarshipList.jsx
@@ -67,61 +67,59 @@ function ScholarshipList({ scholarships }) {
   };
   return (
     <Grid container spacing={3}>
-      {scholarships.map(({ id, data }) => {
-        return (
-          <Grid item xs={12} key={id}>
-            <Card variant="outlined">
-              <CardActionArea
-                component={Link}
-                to={{
-                  pathname: `/scholarships/${id}`,
-                  state: { scholarship: { id, data } },
-                }}>
-                <CardHeader
-                  title={data.name}
-                  subheader={data.amount.toString()}
-                />
-                <CardContent className={classes.content}>
-                  <Typography gutterBottom variant="body1">
-                    Deadline:{' '}
-                    <Typography component="span" color="primary">
-                      {data.deadline.toLocaleDateString()}
-                    </Typography>
+      {scholarships.map(({ id, data }) => (
+        <Grid item xs={12} key={id}>
+          <Card variant="outlined">
+            <CardActionArea
+              component={Link}
+              to={{
+                pathname: `/scholarships/${id}`,
+                state: { scholarship: { id, data } },
+              }}>
+              <CardHeader
+                title={data.name}
+                subheader={data.amount.toString()}
+              />
+              <CardContent className={classes.content}>
+                <Typography gutterBottom variant="body1">
+                  Deadline:{' '}
+                  <Typography component="span" color="primary">
+                    {data.deadline.toLocaleDateString()}
                   </Typography>
-                  <Typography
-                    variant="body1"
-                    color="textSecondary"
-                    className={classes.description}>
-                    {data.description}
-                  </Typography>
-                </CardContent>
-              </CardActionArea>
-              <CardActions className={classes.actions}>
-                <Button
-                  component={MuiLink}
-                  href={data.website}
-                  color="primary"
-                  variant="contained">
-                  Apply
-                </Button>
-                <IconButton
-                  aria-label="add to bookmarks"
-                  color="primary"
-                  // eslint-disable-next-line no-alert
-                  onClick={() => alert('This feature is under construction')}>
-                  <BookmarkBorderIcon />
-                </IconButton>
-                <IconButton
-                  aria-label="share"
-                  color="primary"
-                  onClick={shareFn(id, data)}>
-                  <ShareIcon />
-                </IconButton>
-              </CardActions>
-            </Card>
-          </Grid>
-        );
-      })}
+                </Typography>
+                <Typography
+                  variant="body1"
+                  color="textSecondary"
+                  className={classes.description}>
+                  {data.description}
+                </Typography>
+              </CardContent>
+            </CardActionArea>
+            <CardActions className={classes.actions}>
+              <Button
+                component={MuiLink}
+                href={data.website}
+                color="primary"
+                variant="contained">
+                Apply
+              </Button>
+              <IconButton
+                aria-label="add to bookmarks"
+                color="primary"
+                // eslint-disable-next-line no-alert
+                onClick={() => alert('This feature is under construction')}>
+                <BookmarkBorderIcon />
+              </IconButton>
+              <IconButton
+                aria-label="share"
+                color="primary"
+                onClick={shareFn(id, data)}>
+                <ShareIcon />
+              </IconButton>
+            </CardActions>
+          </Card>
+        </Grid>
+      ))}
       <ShareDialog
         open={shareDialogOpen}
         onClose={closeShareDialog}

--- a/src/pages/ScholarshipDetails.jsx
+++ b/src/pages/ScholarshipDetails.jsx
@@ -34,10 +34,9 @@ export default function ScholarshipDetails({ history, location, match }) {
     }
   }, [history, location]);
 
+  // Fetch the scholarship if we need to load it
   useEffect(() => {
-    // Fetch the scholarship if it wasn't passed
     if (loading) {
-      // Should we maybe set the scholarhip instead of loading every time?
       Scholarships.id(id).get().then(setScholarship).catch(setError);
     }
   }, [id, loading]);

--- a/src/pages/ScholarshipDetails.jsx
+++ b/src/pages/ScholarshipDetails.jsx
@@ -17,6 +17,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 export default function ScholarshipDetails({ history, location, match }) {
+  console.log('history.location', history.location);
   const classes = useStyles();
   const { id } = match.params;
   const [scholarship, setScholarship] = useState(location.state?.scholarship);
@@ -27,16 +28,23 @@ export default function ScholarshipDetails({ history, location, match }) {
     document.title = `${BRAND_NAME} | ${scholarship.data.name}`;
   }
 
+  const passedIn = !!location.state.scholarship;
+  if (passedIn) {
+    console.log('passed in!');
+  }
+
   // clear location scholarship state in case of page refresh
   useEffect(() => {
     if (location.state.scholarship) {
+      console.log('replacing location state for', location);
       history.replace(location.pathname, {});
     }
-  }, [history, location]);
+  });
 
   // fetch the scholarship if it wasn't already passed
   useEffect(() => {
     if (!scholarship) {
+      console.log('fetching...');
       Scholarships.id(id).get().then(setScholarship).catch(setError);
     }
   }, [id, scholarship]);
@@ -51,6 +59,9 @@ export default function ScholarshipDetails({ history, location, match }) {
 
   const { name, amount, deadline, website, description } = scholarship.data;
 
+  if (passedIn) {
+    console.log('rendering passed in scholarship', scholarship.data);
+  }
   return (
     <Container>
       <Typography gutterBottom variant="h3" component="h1">

--- a/src/pages/ScholarshipDetails.jsx
+++ b/src/pages/ScholarshipDetails.jsx
@@ -16,27 +16,23 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export default function ScholarshipDetailsPage({ match }) {
-  const { id } = match.params;
-  const [scholarship, setScholarship] = useState();
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState();
+export default function ScholarshipDetailsPage({ location, match }) {
   const classes = useStyles();
-
-  useEffect(
-    () =>
-      Scholarships.id(id).subscribe(
-        (s) => {
-          document.title = `${BRAND_NAME} | ${s.data.name}`;
-          setScholarship(s);
-          setLoading(false);
-        },
-        (err) => {
-          setError(err);
-        }
-      ),
-    [id]
-  );
+  const { id } = match.params;
+  const [scholarship, setScholarship] = useState({location.state.scholarship});
+  const [error, setError] = useState();
+  const loading = !error && !scholarship;
+  
+  if (loading) {
+    useEffect(() => {
+      Scholarships.id(id)
+        .get()
+        .then(setScholarship)
+        .catch(setError);
+    }, []);
+  } else if (!!scholarship) {
+    document.title = `${BRAND_NAME} | ${s.data.name}`;
+  }
 
   if (error || loading) {
     return (
@@ -79,5 +75,6 @@ export default function ScholarshipDetailsPage({ match }) {
 }
 
 ScholarshipDetailsPage.propTypes = {
+  location: ReactRouterPropTypes.location.isRequired,
   match: ReactRouterPropTypes.match.isRequired,
 };

--- a/src/pages/ScholarshipDetails.jsx
+++ b/src/pages/ScholarshipDetails.jsx
@@ -18,7 +18,6 @@ const useStyles = makeStyles(() => ({
 }));
 
 export default function ScholarshipDetails({ history, location, match }) {
-  console.log('location.state', location.state);
   const classes = useStyles();
   const { id } = match.params;
   const [scholarship, setScholarship] = useState(location.state?.scholarship);
@@ -35,11 +34,11 @@ export default function ScholarshipDetails({ history, location, match }) {
       history.replace({ state: {} });
     }
     // Fetch the scholarship if it wasn't passed
-    if (!scholarship) {
+    if (loading) {
       // Should we maybe set the scholarhip instead of loading every time?
       Scholarships.id(id).get().then(setScholarship).catch(setError);
     }
-  }, [history, id, scholarship]);
+  }, [history, id, loading]);
 
   if (error || loading) {
     return (

--- a/src/pages/ScholarshipDetails.jsx
+++ b/src/pages/ScholarshipDetails.jsx
@@ -16,10 +16,10 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export default function ScholarshipDetails({ location, match }) {
+export default function ScholarshipDetails({ history, location, match }) {
   const classes = useStyles();
   const { id } = match.params;
-  const [scholarship, setScholarship] = useState(location?.state?.scholarship);
+  const [scholarship, setScholarship] = useState(location.state?.scholarship);
   const [error, setError] = useState();
   const loading = !error && !scholarship;
 
@@ -27,6 +27,14 @@ export default function ScholarshipDetails({ location, match }) {
     document.title = `${BRAND_NAME} | ${scholarship.data.name}`;
   }
 
+  // clear location scholarship state in case of page refresh
+  useEffect(() => {
+    if (location.state.scholarship) {
+      history.replace(location.pathname, {});
+    }
+  }, [history, location]);
+
+  // fetch the scholarship if it wasn't already passed
   useEffect(() => {
     if (!scholarship) {
       Scholarships.id(id).get().then(setScholarship).catch(setError);
@@ -74,6 +82,7 @@ export default function ScholarshipDetails({ location, match }) {
 }
 
 ScholarshipDetails.propTypes = {
+  history: ReactRouterPropTypes.history.isRequired,
   location: ReactRouterPropTypes.location.isRequired,
   match: ReactRouterPropTypes.match.isRequired,
 };

--- a/src/pages/ScholarshipDetails.jsx
+++ b/src/pages/ScholarshipDetails.jsx
@@ -70,6 +70,7 @@ export default function ScholarshipDetails({ history, location, match }) {
         className={classes.description}>
         {description}
       </Typography>
+
       <Button
         component={Link}
         href={website}

--- a/src/pages/ScholarshipDetails.jsx
+++ b/src/pages/ScholarshipDetails.jsx
@@ -23,7 +23,7 @@ export default function ScholarshipDetails({ location, match }) {
   const [error, setError] = useState();
   const loading = !error && !scholarship;
 
-  if (location?.state?.scholarship) {
+  if (scholarship) {
     document.title = `${BRAND_NAME} | ${scholarship.data.name}`;
   }
 

--- a/src/pages/ScholarshipDetails.jsx
+++ b/src/pages/ScholarshipDetails.jsx
@@ -16,23 +16,22 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export default function ScholarshipDetailsPage({ location, match }) {
+export default function ScholarshipDetails({ location, match }) {
   const classes = useStyles();
   const { id } = match.params;
-  const [scholarship, setScholarship] = useState({location.state.scholarship});
+  const [scholarship, setScholarship] = useState(location?.state?.scholarship);
   const [error, setError] = useState();
   const loading = !error && !scholarship;
-  
-  if (loading) {
-    useEffect(() => {
-      Scholarships.id(id)
-        .get()
-        .then(setScholarship)
-        .catch(setError);
-    }, []);
-  } else if (!!scholarship) {
-    document.title = `${BRAND_NAME} | ${s.data.name}`;
+
+  if (location?.state?.scholarship) {
+    document.title = `${BRAND_NAME} | ${scholarship.data.name}`;
   }
+
+  useEffect(() => {
+    if (!scholarship) {
+      Scholarships.id(id).get().then(setScholarship).catch(setError);
+    }
+  }, [id, scholarship]);
 
   if (error || loading) {
     return (
@@ -74,7 +73,7 @@ export default function ScholarshipDetailsPage({ location, match }) {
   );
 }
 
-ScholarshipDetailsPage.propTypes = {
+ScholarshipDetails.propTypes = {
   location: ReactRouterPropTypes.location.isRequired,
   match: ReactRouterPropTypes.match.isRequired,
 };

--- a/src/pages/ScholarshipDetails.jsx
+++ b/src/pages/ScholarshipDetails.jsx
@@ -9,7 +9,6 @@ import {
 } from '@material-ui/core';
 import Scholarships from '../models/Scholarships';
 import { BRAND_NAME } from '../config/constants';
-import ScholarshipAmount from '../types/ScholarshipAmount';
 
 const useStyles = makeStyles(() => ({
   description: {
@@ -52,7 +51,7 @@ export default function ScholarshipDetails({ history, location, match }) {
   }
 
   const { name, amount, deadline, website, description } = scholarship.data;
-  console.log(location.state);
+
   return (
     <Container>
       <Typography gutterBottom variant="h3" component="h1">

--- a/src/pages/ScholarshipDetails.jsx
+++ b/src/pages/ScholarshipDetails.jsx
@@ -28,17 +28,20 @@ export default function ScholarshipDetails({ history, location, match }) {
     document.title = `${BRAND_NAME} | ${scholarship.data.name}`;
   }
 
+  // Clear location state in case of refresh/navigation to other pages.
   useEffect(() => {
-    // Clear state in case of refresh/navigation to other pages.
-    if (history.location.state?.scholarship) {
+    if (location.state.scholarship) {
       history.replace({ state: {} });
     }
+  }, [history, location]);
+
+  useEffect(() => {
     // Fetch the scholarship if it wasn't passed
     if (loading) {
       // Should we maybe set the scholarhip instead of loading every time?
       Scholarships.id(id).get().then(setScholarship).catch(setError);
     }
-  }, [history, id, loading]);
+  }, [id, loading]);
 
   if (error || loading) {
     return (
@@ -49,14 +52,14 @@ export default function ScholarshipDetails({ history, location, match }) {
   }
 
   const { name, amount, deadline, website, description } = scholarship.data;
-
+  console.log(location.state);
   return (
     <Container>
       <Typography gutterBottom variant="h3" component="h1">
         {name}
       </Typography>
       <Typography gutterBottom variant="h4" component="h2">
-        {ScholarshipAmount.toString(amount)}
+        {amount.toString()}
       </Typography>
       <Typography gutterBottom variant="h5" component="h3">
         {deadline.toLocaleDateString()}
@@ -68,7 +71,6 @@ export default function ScholarshipDetails({ history, location, match }) {
         className={classes.description}>
         {description}
       </Typography>
-
       <Button
         component={Link}
         href={website}

--- a/src/pages/ScholarshipDetails.jsx
+++ b/src/pages/ScholarshipDetails.jsx
@@ -9,6 +9,7 @@ import {
 } from '@material-ui/core';
 import Scholarships from '../models/Scholarships';
 import { BRAND_NAME } from '../config/constants';
+import ScholarshipAmount from '../types/ScholarshipAmount';
 
 const useStyles = makeStyles(() => ({
   description: {
@@ -17,7 +18,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 export default function ScholarshipDetails({ history, location, match }) {
-  console.log('history.location', history.location);
+  console.log('location.state', location.state);
   const classes = useStyles();
   const { id } = match.params;
   const [scholarship, setScholarship] = useState(location.state?.scholarship);
@@ -28,26 +29,17 @@ export default function ScholarshipDetails({ history, location, match }) {
     document.title = `${BRAND_NAME} | ${scholarship.data.name}`;
   }
 
-  const passedIn = !!location.state.scholarship;
-  if (passedIn) {
-    console.log('passed in!');
-  }
-
-  // clear location scholarship state in case of page refresh
   useEffect(() => {
-    if (location.state.scholarship) {
-      console.log('replacing location state for', location);
-      history.replace(location.pathname, {});
+    // Clear state in case of refresh/navigation to other pages.
+    if (history.location.state?.scholarship) {
+      history.replace({ state: {} });
     }
-  });
-
-  // fetch the scholarship if it wasn't already passed
-  useEffect(() => {
+    // Fetch the scholarship if it wasn't passed
     if (!scholarship) {
-      console.log('fetching...');
+      // Should we maybe set the scholarhip instead of loading every time?
       Scholarships.id(id).get().then(setScholarship).catch(setError);
     }
-  }, [id, scholarship]);
+  }, [history, id, scholarship]);
 
   if (error || loading) {
     return (
@@ -59,16 +51,13 @@ export default function ScholarshipDetails({ history, location, match }) {
 
   const { name, amount, deadline, website, description } = scholarship.data;
 
-  if (passedIn) {
-    console.log('rendering passed in scholarship', scholarship.data);
-  }
   return (
     <Container>
       <Typography gutterBottom variant="h3" component="h1">
         {name}
       </Typography>
       <Typography gutterBottom variant="h4" component="h2">
-        {amount.toString()}
+        {ScholarshipAmount.toString(amount)}
       </Typography>
       <Typography gutterBottom variant="h5" component="h3">
         {deadline.toLocaleDateString()}

--- a/src/pages/ScholarshipDetails.test.jsx
+++ b/src/pages/ScholarshipDetails.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { Router, Route } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
+import { MemoryRouter, Route } from 'react-router-dom';
 import { clearFirestoreData, initializeTestApp } from '../lib/testing';
 import ScholarshipDetails from './ScholarshipDetails';
 import Scholarships from '../models/Scholarships';
@@ -12,13 +11,11 @@ import AmountType from '../types/AmountType';
 // TODO: Figure out a cleaner solution.
 window.MutationObserver = require('mutation-observer');
 
-function renderAtRoute(route, state = {}) {
-  const history = createMemoryHistory();
-  history.replace(route, state);
+function renderAtRoute(pathname, state = {}) {
   return render(
-    <Router history={history}>
+    <MemoryRouter initialEntries={[{ pathname, state }]}>
       <Route path="/scholarships/:id" component={ScholarshipDetails} />
-    </Router>
+    </MemoryRouter>
   );
 }
 
@@ -57,7 +54,7 @@ test('renders passed in scholarship details', async () => {
     scholarship: { id: 'abc', data },
   });
 
-  await screen.findByText(data.name); //).toBeInTheDocument();
+  expect(screen.getByText(data.name)).toBeInTheDocument();
   expect(screen.getByText(data.amount.toString())).toBeInTheDocument();
   expect(screen.getByText(data.description)).toBeInTheDocument();
   expect(

--- a/src/pages/ScholarshipDetails.test.jsx
+++ b/src/pages/ScholarshipDetails.test.jsx
@@ -66,6 +66,7 @@ test('renders passed in scholarship details', () => {
     screen.getByText(data.deadline.toLocaleDateString())
   ).toBeInTheDocument();
   expect(screen.getByRole('button').href).toBe(data.website);
+  expect(document.title).toContain(data.name);
 });
 
 test('renders scholarship details', async () => {
@@ -93,4 +94,5 @@ test('renders scholarship details', async () => {
     screen.getByText(data.deadline.toLocaleDateString())
   ).toBeInTheDocument();
   expect(screen.getByRole('button').href).toBe(data.website);
+  expect(document.title).toContain(data.name);
 });

--- a/src/pages/ScholarshipDetails.test.jsx
+++ b/src/pages/ScholarshipDetails.test.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Router, Route } from 'react-router-dom';
-import { clearFirestoreData, initializeTestApp } from '../lib/testing';
-import firebase from 'firebase';
 import { createMemoryHistory } from 'history';
+import { clearFirestoreData, initializeTestApp } from '../lib/testing';
 import ScholarshipDetails from './ScholarshipDetails';
 import Scholarships from '../models/Scholarships';
 import ScholarshipAmount from '../types/ScholarshipAmount';
@@ -38,7 +37,7 @@ test('renders loading initially', async () => {
 test('renders scholarship not found', async () => {
   renderAtRoute('/scholarships/bad-id');
 
-  await screen.findByText(/Scholarships\/bad-id Not Found/i);
+  await screen.findByText(/scholarships\/bad-id Not Found/i);
 });
 
 test('renders passed in scholarship details', async () => {

--- a/src/pages/ScholarshipDetails.test.jsx
+++ b/src/pages/ScholarshipDetails.test.jsx
@@ -41,7 +41,7 @@ test('renders scholarship not found', async () => {
   await screen.findByText(/Scholarships\/bad-id Not Found/i);
 });
 
-test('renders passed in scholarship details', () => {
+test('renders passed in scholarship details', async () => {
   const data = {
     name: 'Foo scholarship',
     amount: new ScholarshipAmount({
@@ -53,13 +53,12 @@ test('renders passed in scholarship details', () => {
     deadline: new Date('2020-12-17'),
     website: 'http://foo.com/',
   };
-  const scholarship = Scholarships.id('abc');
-  scholarship.data = data;
 
-  renderAtRoute('/scholarships/abc', { scholarship });
+  renderAtRoute('/scholarships/passed-in', {
+    scholarship: { id: 'abc', data },
+  });
 
-  expect(screen.getByText(/Scholarship/i)).toBeInTheDocument();
-  expect(screen.getByText(data.name)).toBeInTheDocument();
+  await screen.findByText(data.name); //).toBeInTheDocument();
   expect(screen.getByText(data.amount.toString())).toBeInTheDocument();
   expect(screen.getByText(data.description)).toBeInTheDocument();
   expect(

--- a/src/pages/Scholarships.jsx
+++ b/src/pages/Scholarships.jsx
@@ -24,15 +24,9 @@ function ScholarshipsPage() {
   useEffect(() => {
     // TODO: Create cancellable promises
     Scholarships.list({ sortField: 'deadline' })
-      .then((results) => {
-        setScholarships(results);
-      })
-      .catch((err) => {
-        setError(err);
-      })
-      .finally(() => {
-        setLoading(false);
-      });
+      .then(setScholarships)
+      .catch(setError)
+      .finally(() => setLoading(false));
   }, []);
 
   const classes = useStyles();

--- a/src/types/ScholarshipAmount.ts
+++ b/src/types/ScholarshipAmount.ts
@@ -34,16 +34,25 @@ export default class ScholarshipAmount {
   }
 
   toString(): string {
-    switch (this.type) {
+    return ScholarshipAmount.toString(this);
+  }
+
+  static toString(data: {
+    type?: AmountType;
+    min?: number;
+    max?: number;
+  }): string {
+    const { type, min, max } = data;
+    switch (type) {
       case AmountType.FullTuition:
         return 'Full Tuition';
       case AmountType.Fixed:
-        return `$${this.min}`;
+        return `$${min}`;
       case AmountType.Range:
-        if (this.min && this.max) {
-          return `$${this.min}-$${this.max}`;
+        if (min && max) {
+          return `$${min}-$${max}`;
         }
-        return this.min ? `$${this.min}+` : `Up to $${this.max}`;
+        return min ? `$${min}+` : `Up to $${max}`;
       default:
         return '(Unknown amount)';
     }

--- a/src/types/ScholarshipAmount.ts
+++ b/src/types/ScholarshipAmount.ts
@@ -34,25 +34,16 @@ export default class ScholarshipAmount {
   }
 
   toString(): string {
-    return ScholarshipAmount.toString(this);
-  }
-
-  static toString(data: {
-    type?: AmountType;
-    min?: number;
-    max?: number;
-  }): string {
-    const { type, min, max } = data;
-    switch (type) {
+    switch (this.type) {
       case AmountType.FullTuition:
         return 'Full Tuition';
       case AmountType.Fixed:
-        return `$${min}`;
+        return `$${this.min}`;
       case AmountType.Range:
-        if (min && max) {
-          return `$${min}-$${max}`;
+        if (this.min && this.max) {
+          return `$${this.min}-$${this.max}`;
         }
-        return min ? `$${min}+` : `Up to $${max}`;
+        return this.min ? `$${this.min}+` : `Up to $${this.max}`;
       default:
         return '(Unknown amount)';
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,11 +1117,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-<<<<<<< HEAD
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
-=======
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
->>>>>>> fix tests and slight bugs
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,7 +1117,11 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+<<<<<<< HEAD
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+=======
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+>>>>>>> fix tests and slight bugs
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -7372,6 +7376,13 @@ history@^4.9.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
+
+history@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0.tgz#0cabbb6c4bbf835addb874f8259f6d25101efd08"
+  integrity sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe or list your changes in detail -->

- Pass scholarship data from results page to detail page via [location.state](https://reactrouter.com/web/api/location)
- In detail page, only fetch data if needed
- In detail page, clear location state so that refreshing the page works (we might at some point want to remove this but for now it's unintuitive if the data doesn't update on refresh).

Additionally:
- Persist Firestore emulator data across `yarn start` sessions. This'll prevent us from having to create scholarships each time.
- Fix warnings `yarn test` was complaining about.
- Silence lint warnings.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #204. This reduces having to make another Firestore call in the detail view when we already have that data in the list view. There shouldn't be a need to re-fetch data we already have.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Are these changes covered by new tests or existing tests? -->
<!--- How else did you test these changes? -->

I added a new test that makes sure the passed in scholarship data is rendered immediately if it's passed in. Existing tests assume no location state has been passed in.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## Previewing Changes

<!--- Delete this section if there are no user visible changes. --->
<!--- List out the steps needed to preview the user visible changes. --->
<!--- Be very specific about what to look for and what things to try. --->

1. Go to https://s4us-pr-237.onrender.com/scholarships.
2. Click on a result.
3. Notice how it doesn't say **Loading...** anymore. This is because the scholarship data was immediately passed in.
4. Refresh the page
5. Notice how it says **Loading...** for a split second, reflecting the refresh request.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
