### PR TITLE
Set dev Firebase config to match default project

### DIFF
--- a/src/lib/FirebaseProvider.tsx
+++ b/src/lib/FirebaseProvider.tsx
@@ -22,12 +22,8 @@ export default function FirebaseProvider(props: {
     if (process.env.NODE_ENV === 'production') {
       firebase.initializeApp(config);
     } else {
-      firebase.initializeApp({
-        // TODO (issues/214): Setup auth emulator once supported
-        apiKey: 'AIzaSyAXDqsWK4quNVaf9-YV2e28NsxkfA9rzJA',
-        authDomain: 'dreamerscholars.firebaseapp.com',
-        projectId: 'dreamerscholars-dev',
-      });
+      // TODO (issues/214): Setup auth emulator once supported
+      firebase.initializeApp(config);
       firebase.firestore().settings({ host: 'localhost:8080', ssl: false });
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

As a developer any Firestore changes you make in the Emulator UI doesn't get reflected in the React app. This is because the UI is emulating for the `dreamscholars` project while the React app is trying to talk to `dreamscholars-dev`.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Are these changes covered by new tests or existing tests? -->
<!--- How else did you test these changes? -->

I've tried it locally.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] User visible change (users will notice UI or functional changes)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
