### PR TITLE
Decrease dependency updates to once a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 10
     versioning-strategy: increase-if-necessary


### PR DESCRIPTION
So we get less dependabot PRs but still get updates frequently enough :)