### PR TITLE
Make ScholarshipAmount min/maxes sortable regardless of type

### DIFF
--- a/src/models/Scholarships.test.ts
+++ b/src/models/Scholarships.test.ts
@@ -14,10 +14,9 @@ afterAll(async () => app.delete());
 test('converter.toFirestore', () => {
   const data = {
     name: 'scholarship',
-    amount: new ScholarshipAmount({
+    amount: new ScholarshipAmount(AmountType.Fixed, {
       min: 2500,
       max: 2500,
-      type: AmountType.Fixed,
     }),
     description: 'description',
     deadline: new Date('2019-02-20'),
@@ -37,7 +36,10 @@ test('converter.toFirestore', () => {
 test('converter.fromFirestore', () => {
   const snapdata: firestore.DocumentData = {
     name: 'scholarship',
-    amount: { min: 2500, max: 2500, type: AmountType.Fixed },
+    amount: new ScholarshipAmount(AmountType.Fixed, {
+      min: 2500,
+      max: 2500,
+    }),
     description: 'description',
     deadline: firestore.Timestamp.fromDate(new Date('2019-02-20')),
     website: 'mit.com',

--- a/src/models/Scholarships.ts
+++ b/src/models/Scholarships.ts
@@ -29,7 +29,7 @@ export const converter: firestore.FirestoreDataConverter<ScholarshipData> = {
   fromFirestore: (snapshot, options) => {
     const data = snapshot.data(options);
     const deadline = (data.deadline as firestore.Timestamp).toDate();
-    const amount = new ScholarshipAmount(data.amount);
+    const amount = new ScholarshipAmount(data.amount.type, data.amount);
     return { ...data, amount, deadline } as ScholarshipData;
   },
 };

--- a/src/types/ScholarshipAmount.test.ts
+++ b/src/types/ScholarshipAmount.test.ts
@@ -1,17 +1,31 @@
 import AmountType from './AmountType';
-import ScholarshipAmount from './ScholarshipAmount';
+import ScholarshipAmount, {
+  FULL_TUITION_VALUE,
+  UNKNOWN_MAX,
+  UNKNOWN_MIN,
+} from './ScholarshipAmount';
 
 test('constructor defaults', () => {
   const amount = new ScholarshipAmount();
 
   expect(amount.type).toBe(AmountType.Unknown);
-  expect(amount.min).toBe(0);
-  expect(amount.max).toBe(0);
+  expect(amount.min).toBe(UNKNOWN_MIN);
+  expect(amount.max).toBe(UNKNOWN_MAX);
 });
 
-test('constructor with values', () => {
-  const amount = new ScholarshipAmount({
-    type: AmountType.Range,
+test('constructor - fixed', () => {
+  const amount = new ScholarshipAmount(AmountType.Fixed, {
+    min: 20,
+    max: 20,
+  });
+
+  expect(amount.type).toBe(AmountType.Fixed);
+  expect(amount.min).toBe(20);
+  expect(amount.max).toBe(20);
+});
+
+test('constructor - range', () => {
+  const amount = new ScholarshipAmount(AmountType.Range, {
     min: 2,
     max: 20,
   });
@@ -21,11 +35,26 @@ test('constructor with values', () => {
   expect(amount.max).toBe(20);
 });
 
+test('constructor - full tuition', () => {
+  const amount = new ScholarshipAmount(AmountType.FullTuition);
+
+  expect(amount.type).toBe(AmountType.FullTuition);
+  expect(amount.min).toBe(FULL_TUITION_VALUE);
+  expect(amount.max).toBe(FULL_TUITION_VALUE);
+});
+
+test('constructor - unknown', () => {
+  const amount = new ScholarshipAmount(AmountType.Unknown);
+
+  expect(amount.type).toBe(AmountType.Unknown);
+  expect(amount.min).toBe(UNKNOWN_MIN);
+  expect(amount.max).toBe(UNKNOWN_MAX);
+});
+
 test('constructor exceptions - fixed min != max', () => {
   expect(
     () =>
-      new ScholarshipAmount({
-        type: AmountType.Fixed,
+      new ScholarshipAmount(AmountType.Fixed, {
         min: 2,
         max: 20,
       })
@@ -35,36 +64,44 @@ test('constructor exceptions - fixed min != max', () => {
 test('constructor exceptions - fixed value not positive', () => {
   expect(
     () =>
-      new ScholarshipAmount({
-        type: AmountType.Fixed,
+      new ScholarshipAmount(AmountType.Fixed, {
         min: 0,
       })
-  ).toThrow(/.*invalid fixed amount*/i);
+  ).toThrow(/.*not a positive number*/i);
 });
 
 test('constructor exceptions - range min negative', () => {
   expect(
     () =>
-      new ScholarshipAmount({
-        type: AmountType.Range,
+      new ScholarshipAmount(AmountType.Range, {
         min: -2,
       })
   ).toThrow(/.*invalid min*/i);
 });
+
 test('constructor exceptions - range max negative', () => {
   expect(
     () =>
-      new ScholarshipAmount({
-        type: AmountType.Range,
+      new ScholarshipAmount(AmountType.Range, {
         max: -2,
       })
   ).toThrow(/.*invalid max*/i);
 });
+
+test('constructor exceptions - range no bounds', () => {
+  expect(
+    () =>
+      new ScholarshipAmount(AmountType.Range, {
+        min: 20,
+        max: 2,
+      })
+  ).toThrow(/.*invalid range*/i);
+});
+
 test('constructor exceptions - range max <= min', () => {
   expect(
     () =>
-      new ScholarshipAmount({
-        type: AmountType.Range,
+      new ScholarshipAmount(AmountType.Range, {
         min: 20,
         max: 2,
       })
@@ -72,7 +109,7 @@ test('constructor exceptions - range max <= min', () => {
 });
 
 test('toString - Unknown', () => {
-  const amount = new ScholarshipAmount({ type: AmountType.Unknown });
+  const amount = new ScholarshipAmount(AmountType.Unknown);
 
   const res = amount.toString();
 
@@ -80,7 +117,7 @@ test('toString - Unknown', () => {
 });
 
 test('toString - FullTuition', () => {
-  const amount = new ScholarshipAmount({ type: AmountType.FullTuition });
+  const amount = new ScholarshipAmount(AmountType.FullTuition);
 
   const res = amount.toString();
 
@@ -88,8 +125,7 @@ test('toString - FullTuition', () => {
 });
 
 test('toString - Fixed', () => {
-  const amount = new ScholarshipAmount({
-    type: AmountType.Fixed,
+  const amount = new ScholarshipAmount(AmountType.Fixed, {
     min: 1000,
     max: 1000,
   });
@@ -100,7 +136,7 @@ test('toString - Fixed', () => {
 });
 
 test('toString - Range - min only', () => {
-  const amount = new ScholarshipAmount({ type: AmountType.Range, min: 1000 });
+  const amount = new ScholarshipAmount(AmountType.Range, { min: 1000 });
 
   const res = amount.toString();
 
@@ -108,7 +144,7 @@ test('toString - Range - min only', () => {
 });
 
 test('toString - Range - max only', () => {
-  const amount = new ScholarshipAmount({ type: AmountType.Range, max: 1000 });
+  const amount = new ScholarshipAmount(AmountType.Range, { max: 1000 });
 
   const res = amount.toString();
 
@@ -116,8 +152,7 @@ test('toString - Range - max only', () => {
 });
 
 test('toString - Range - min and max', () => {
-  const amount = new ScholarshipAmount({
-    type: AmountType.Range,
+  const amount = new ScholarshipAmount(AmountType.Range, {
     min: 1000,
     max: 2500,
   });

--- a/src/types/ScholarshipAmount.test.ts
+++ b/src/types/ScholarshipAmount.test.ts
@@ -110,13 +110,9 @@ test('constructor exceptions - range max negative', () => {
 });
 
 test('constructor exceptions - range no bounds', () => {
-  expect(
-    () =>
-      new ScholarshipAmount(AmountType.Range, {
-        min: 20,
-        max: 2,
-      })
-  ).toThrow(/.*invalid range*/i);
+  expect(() => new ScholarshipAmount(AmountType.Range, {})).toThrow(
+    /.*at least one bound is required*/i
+  );
 });
 
 test('constructor exceptions - range max <= min', () => {

--- a/src/types/ScholarshipAmount.test.ts
+++ b/src/types/ScholarshipAmount.test.ts
@@ -1,6 +1,7 @@
 import AmountType from './AmountType';
 import ScholarshipAmount, {
-  FULL_TUITION_VALUE,
+  FULL_TUITION,
+  RANGE_MAX,
   UNKNOWN_MAX,
   UNKNOWN_MIN,
 } from './ScholarshipAmount';
@@ -35,12 +36,32 @@ test('constructor - range', () => {
   expect(amount.max).toBe(20);
 });
 
+test('constructor - range no min', () => {
+  const amount = new ScholarshipAmount(AmountType.Range, {
+    max: 20,
+  });
+
+  expect(amount.type).toBe(AmountType.Range);
+  expect(amount.min).toBe(0);
+  expect(amount.max).toBe(20);
+});
+
+test('constructor - range no max', () => {
+  const amount = new ScholarshipAmount(AmountType.Range, {
+    min: 2,
+  });
+
+  expect(amount.type).toBe(AmountType.Range);
+  expect(amount.min).toBe(2);
+  expect(amount.max).toBe(RANGE_MAX);
+});
+
 test('constructor - full tuition', () => {
   const amount = new ScholarshipAmount(AmountType.FullTuition);
 
   expect(amount.type).toBe(AmountType.FullTuition);
-  expect(amount.min).toBe(FULL_TUITION_VALUE);
-  expect(amount.max).toBe(FULL_TUITION_VALUE);
+  expect(amount.min).toBe(FULL_TUITION);
+  expect(amount.max).toBe(FULL_TUITION);
 });
 
 test('constructor - unknown', () => {

--- a/src/types/ScholarshipAmount.ts
+++ b/src/types/ScholarshipAmount.ts
@@ -1,12 +1,17 @@
 import AmountType from './AmountType';
 
-export const FULL_TUITION_VALUE = 10000000001;
+// To make sorting by amount.max make sense for range amounts
+// with no upper bound.
+export const RANGE_MAX = 1000000001;
 
-// To make Unknown amounts appear last when sorting by amount we
-// purposefully make:
-// - min > FULL_TUITION (for low->high sorting)
-// - max < 0            (for high->low sorting)
-export const UNKNOWN_MIN = FULL_TUITION_VALUE + 1;
+// To make sorting by amount.min/max make sense for full tuition amounts.
+export const FULL_TUITION = RANGE_MAX + 1;
+
+// To make sorting by amount.min/max make sense for unknown amounts.
+// In order to make unknown amounts appear last we purposefully make:
+// - min > FULL_TUITION (for low->high amount.min sorting)
+// - max < 0            (for high->low amount.max sorting)
+export const UNKNOWN_MIN = FULL_TUITION + 1;
 export const UNKNOWN_MAX = -1;
 
 export default class ScholarshipAmount {
@@ -46,11 +51,11 @@ export default class ScholarshipAmount {
           throw new Error(`Invalid range ${min}-${max}`);
         }
         this.min = min ?? 0;
-        this.max = max ?? FULL_TUITION_VALUE;
+        this.max = max ?? RANGE_MAX;
         break;
       case AmountType.FullTuition:
-        this.min = FULL_TUITION_VALUE;
-        this.max = FULL_TUITION_VALUE;
+        this.min = FULL_TUITION;
+        this.max = FULL_TUITION;
         break;
       default:
         // amount unknown
@@ -66,7 +71,7 @@ export default class ScholarshipAmount {
       case AmountType.Fixed:
         return `$${this.min}`;
       case AmountType.Range:
-        if (this.min && this.max !== FULL_TUITION_VALUE) {
+        if (this.min && this.max !== RANGE_MAX) {
           return `$${this.min}-$${this.max}`;
         }
         return this.min ? `$${this.min}+` : `Up to $${this.max}`;

--- a/src/types/ScholarshipAmount.ts
+++ b/src/types/ScholarshipAmount.ts
@@ -45,7 +45,7 @@ export default class ScholarshipAmount {
           throw new Error(`Invalid max amount: ${max}.`);
         }
         if (!max && !min) {
-          throw new Error(`Range amount cannot be undefined.`);
+          throw new Error(`No bounds given. At least one bound is required.`);
         }
         if (max && min && min >= max) {
           throw new Error(`Invalid range ${min}-${max}`);


### PR DESCRIPTION

## Description

<!--- Describe or list your changes in detail -->
This allows sorting by min/max make sense regardless of amount type (as long as scholarship award amounts don't surpass $1 billion).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #344 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Are these changes covered by new tests or existing tests? -->
<!--- How else did you test these changes? -->

I added tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] User visible change (users will notice UI or functional changes)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
