### PR TITLE
Optimize style validation job by only installing Prettier

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,20 +55,10 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile --prefer-offline
+      - name: Install Prettier
+        run: yarn global add prettier
       - name: Style
-        run: yarn prettier --check . || yarn prettier --write . && git diff --exit-code
+        run: $(yarn global bin)/prettier --check . || $(yarn global bin)/prettier --write . && git diff --exit-code
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,8 +55,8 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2
-      - name: Install Prettier
-        run: yarn global add prettier
+      -   name: Install Prettier
+          run: yarn global add prettier
       - name: Style
         run: $(yarn global bin)/prettier --check . || $(yarn global bin)/prettier --write . && git diff --exit-code
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,8 +55,8 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2
-      -   name: Install Prettier
-          run: yarn global add prettier
+      - name: Install Prettier
+        run: yarn global add prettier
       - name: Style
         run: $(yarn global bin)/prettier --check . || $(yarn global bin)/prettier --write . && git diff --exit-code
 


### PR DESCRIPTION
Our style job only relies on prettier so rather than install everything from package.json let's just install prettier alone.

<!--- Describe or list your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If you look at the [Validation actions](https://github.com/beyondhb1079/s4us/actions?query=workflow%3AValidation) the `style` validation job is usually the fastest at around `1m10s` or so. But... this can be made faster by ignoring all other dependencies. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Are these changes covered by new tests or existing tests? -->
<!--- How else did you test these changes? -->
Look at how fast `style` jobs have run in the [checks](371/checks) for this PR for each commit. Blazing fast under 10 seconds!
