### PR TITLE
Remove testing from pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "yarn lint && firebase emulators:exec --only firestore 'react-scripts test --watchAll=false'"
+      "pre-push": "yarn lint"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
<!--- SUMMARIZE your changes in the Title above -->
<!--- Detail any specific changes here -->

## Motivation and Context

<!--- EXPLAIN why this change is required. -->
<!--- Link any relevant issues via "Fixes #" or "Helps with #". -->

Now that #374 has sped up validation check tests significantly I think we can remove this overhead from pushing. We should really be pushing often and the 1.5-2.5 minutes this takes discourages you from pushing often. I had introduced it to catch things sooner but it's probably causing more toil than helping, especially now that it takes less than a minute to get feedback form the validation check.

Note: I've kept linting in the pre-push as that only takes around 30 seconds and it'll catch some things the build check will complain about.