### PR TITLE
fix firestore indexes deadline field typo

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -5,7 +5,7 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "amount.min", "order": "ASCENDING" },
-        { "fieldPath": "amount.deadline", "order": "ASCENDING" }
+        { "fieldPath": "deadline", "order": "ASCENDING" }
       ]
     },
     {
@@ -13,7 +13,7 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "authorId", "order": "ASCENDING" },
-        { "fieldPath": "amount.deadline", "order": "ASCENDING" }
+        { "fieldPath": "deadline", "order": "ASCENDING" }
       ]
     },
     {
@@ -21,7 +21,7 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "amount.max", "order": "DESCENDING" },
-        { "fieldPath": "amount.deadline", "order": "ASCENDING" }
+        { "fieldPath": "deadline", "order": "ASCENDING" }
       ]
     }
   ],


### PR DESCRIPTION
<!--- SUMMARIZE your changes in the Title above -->
<!--- Detail any specific changes here -->

## Motivation and Context

<!--- EXPLAIN why this change is required. -->
<!--- Link any relevant issues via "Fixes #" or "Helps with #". -->

Our CI workflows have been failing ever since I submitted #409:
https://github.com/beyondhb1079/s4us/actions/workflows/deploy.yml

## How Has This Been Tested?

<!--- DESCRIBE in detail how you tested your changes. -->
<!--- Are these changes covered by new tests or existing tests? -->
<!--- How else did you test these changes? -->

I compared with the output of `firebase firestore:indexes` and found that we sillily wrote `amount.deadline` instead of `deadline`.

## Types of changes

<!--- CHECK all the types of changes introduced by replacing "[ ]" with "[x]" in the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] User visible change (users will notice UI or functional changes)


## Checklist:

<!--- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
