### PR TITLE
Update autoapprove dependabot action to use github-script@v3

### DIFF
--- a/.github/workflows/dependabot-autoapprove.yml
+++ b/.github/workflows/dependabot-autoapprove.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v2
       - name: Automerge
-        uses: actions/github-script@0.2.0
+        uses: actions/github-script@v3
         with:
           script: |
             // Skip if there are any approvals
@@ -44,4 +44,4 @@ jobs:
                     'this auto merged: \n' +
                     '@dependabot squash and merge'
             })
-          github-token: ${{github.token}}
+          github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-autoapprove.yml
+++ b/.github/workflows/dependabot-autoapprove.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2
-      - name: Automerge
+      - name: Autoapprove
         uses: actions/github-script@v3
         with:
           script: |
@@ -44,4 +44,4 @@ jobs:
                     'this auto merged: \n' +
                     '@dependabot squash and merge'
             })
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{github.token}}


### PR DESCRIPTION
<!--- SUMMARIZE your changes in the Title above -->
<!--- Detail any specific changes here -->

This action has been failing lately:
https://github.com/beyondhb1079/s4us/actions/workflows/dependabot-autoapprove.yml

I think it might be because we're using an older version of github-script.
