### PR TITLE
fixed the glitch user home page flickers no scholarships when loading

### DIFF
--- a/src/pages/UserHome.jsx
+++ b/src/pages/UserHome.jsx
@@ -138,40 +138,42 @@ export default function UserHome() {
           </Button>
         </Grid>
       </Grid>
-      {error?.toString() ||
-      (loading && <CircularProgress className={classes.progress} />) ||
-      scholarships.length === 0 ? (
-        <Grid
-          container
-          component={Paper}
-          variant="outlined"
-          className={classes.noneAddedGrid}>
-          <Grid item>
-            <InboxIcon className={classes.inboxIcon} />
-          </Grid>
-          <Grid item>
-            <Typography variant="h5" gutterButtom>
-              No Scholarships Added Yet
-            </Typography>
-            <MuiLink component={Link} to="/scholarships/new">
-              Add Scholarship
-            </MuiLink>
-          </Grid>
-        </Grid>
+      {error?.toString() || loading ? (
+        <CircularProgress className={classes.progress} />
       ) : (
-        <>
-          <ScholarshipList scholarships={scholarships} />
-          {canLoadMore ? (
-            <Button
-              className={classes.loadMoreButton}
-              color="primary"
-              onClick={() => loadMoreScholarships(loadMoreFn)}>
-              Load More
-            </Button>
+        [
+          scholarships.length === 0 ? (
+            <Grid
+              container
+              component={Paper}
+              variant="outlined"
+              className={classes.noneAddedGrid}>
+              <Grid item>
+                <InboxIcon className={classes.inboxIcon} />
+              </Grid>
+              <Grid item>
+                <Typography variant="h5" gutterButtom>
+                  No Scholarships Added Yet
+                </Typography>
+                <MuiLink component={Link} to="/scholarships/new">
+                  Add Scholarship
+                </MuiLink>
+              </Grid>
+            </Grid>
           ) : (
-            'No more results'
-          )}
-        </>
+            <>
+              <ScholarshipList scholarships={scholarships} />
+              {canLoadMore && (
+                <Button
+                  className={classes.loadMoreButton}
+                  color="primary"
+                  onClick={() => loadMoreScholarships(loadMoreFn)}>
+                  Load More
+                </Button>
+              )}
+            </>
+          ),
+        ]
       )}
     </Container>
   );


### PR DESCRIPTION
## Motivation and Context

It does not make sense as a user that has added a scholarship to have the "no scholarships component" appear as they should only see their list of scholarships added.
Users that have not added a scholarship will remain the same as they will be viewing the "no scholarships component".

Fixes #468 

## How Has This Been Tested?

Used the emulator to create a user that has a scholarship added and refreshed the page to ensure the "no scholarships component" does appear after loading scholarships. The list of added scholarships do appear and also removed the text that said "no more results".

Then I created another user in the emulator that does not have any scholarships added and the loading happens and after the "no scholarships component" does appear. 

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] User visible change (users will notice UI or functional changes)

## Previewing Changes

1. Go to https://s4us-pr-486.onrender.com.
2. Login
3. There can be two scenarios: you haven't added scholarships the "no scholarships component" would appear, but if you have added a scholarship and you refresh the page you will notice that there is a loading that appears for a second then your added scholarships list will appear.

## Checklist:

- [ ] I have added tests to cover my changes.
* Pending test case to add