### PR TITLE
Finally fix autoapprove dependabot workflow

### DIFF
--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -4,53 +4,7 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
-  autoapprove-dependabot:
-    runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
-    name: Approve dependabot changes
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v2
-      - name: Autoapprove
-        uses: actions/github-script@v4
-        with:
-          script: |
-            const owner = context.payload.repository.owner.login;
-            const repo = context.payload.repository.name;
-            const pull_number = context.payload.pull_request.number;
-
-            github.pulls
-              .listReviews({ owner, repo, pull_number })
-              .then((response) =>
-                response.data
-                  .filter(r => r.state == 'APPROVED')
-                  .filter(r => r.user.login = 'github-actions[bot]')
-              )
-              .then((approvals) => {
-                if (approvals.length !== 0) {
-                  console.log('I already approved this PR! :)');
-                  return;
-                }
-
-                // Approve and leave a comment for the human reviewer.
-                const body =
-                  'Dear human reviewer, copy and paste this to auto merge: \n' +
-                  '@dependabot squash and merge';
-                const event = 'APPROVE';
-                return github.pulls.createReview({
-                  owner,
-                  repo,
-                  pull_number,
-                  body,
-                  event,
-                });
-              });
-
   dismiss-stale-approvals:
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   autoapprove-dependabot:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,52 @@
+name: 'Dependabot'
+
+on:
+  pull_request_target:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  autoapprove:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    name: Autoapprove
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+      - name: Autoapprove
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const owner = context.payload.repository.owner.login;
+            const repo = context.payload.repository.name;
+            const pull_number = context.payload.pull_request.number;
+
+            github.pulls
+              .listReviews({ owner, repo, pull_number })
+              .then((response) =>
+                response.data
+                  .filter(r => r.state == 'APPROVED')
+                  .filter(r => r.user.login = 'github-actions[bot]')
+              )
+              .then((approvals) => {
+                if (approvals.length !== 0) {
+                  console.log('I already approved this PR! :)');
+                  return;
+                }
+
+                // Approve and leave a comment for the human reviewer.
+                const body =
+                  'Dear human reviewer, copy and paste this to auto merge: \n' +
+                  '@dependabot squash and merge';
+                const event = 'APPROVE';
+                return github.pulls.createReview({
+                  owner,
+                  repo,
+                  pull_number,
+                  body,
+                  event,
+                });
+              });


### PR DESCRIPTION
I finally understand why `dependabot` triggered checks like https://github.com/beyondhb1079/s4us/pull/534/checks?check_run_id=2969026240 keep failing.

For security reasons, the default [permissions](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token) on the GitHub token is read-only for Dependabot pull requests so we have to use the `pull_request_target` event instead.

Additional details in dependabot/dependabot-core#3253.
