### PR TITLE
Fix CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: '12'
-      - run: yarn install --frozen-lockfile --production
+      - run: yarn install --frozen-lockfile
       - run: yarn build --frozen-lockfile
       - uses: w9jds/firebase-action@master
         name: Deploy app and firestore rules/indices


### PR DESCRIPTION
It looks like yarn build now has some dependencies on our dev dependencies :/

## Context
https://github.com/beyondhb1079/s4us/runs/3034499921