### PR TITLE
Set the auth domain to dreamscholars.org

### DIFF
--- a/src/lib/FirebaseProvider.tsx
+++ b/src/lib/FirebaseProvider.tsx
@@ -7,7 +7,7 @@ const config = {
   // TODO (issues/213): Configure a separate staging project.
   // These values should really be read from the environment.
   apiKey: 'AIzaSyAXDqsWK4quNVaf9-YV2e28NsxkfA9rzJA',
-  authDomain: 'dreamerscholars.firebaseapp.com',
+  authDomain: 'auth.dreamscholars.org',
   projectId: 'dreamerscholars',
 };
 


### PR DESCRIPTION
Just tried it out against the live site. When you try logging in it no longer displays the firebaseapp.com domain.