### PR TITLE
Don't dismiss approval on clean merges

### DIFF
--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -60,7 +60,7 @@ jobs:
               echo "An unclean merge happened";
             else
               echo "No unclean merges";
-              MERGE_COMMIT_MSG="Merge branch 'main' into ${GITHUB_REF#refs/heads/}";
+              MERGE_COMMIT_MSG="Merge branch 'main' into ${GITHUB_HEAD_REF}";
               PATH_LENGTH=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | wc -l);
               NUM_MERGES=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | grep "$MERGE_COMMIT_MSG" | wc -l);
               echo reached here

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
+            set -v
             const owner = context.payload.repository.owner.login;
             const repo = context.payload.repository.name;
             const pull_number = context.payload.pull_request.number;

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -32,11 +32,11 @@ jobs:
               console.log('No approvals given.');
               return;
             }
-            
+
             const approval = approvals[0];
             const commitHash = approval.commit_id;
             console.log(`Last approved at commit ${commitHash} by ${approval.user.login}.`);
-            
+
             // Set APPROVED_SHA environment variable
             const fs = require('fs');
             fs.appendFileSync(process.env.GITHUB_ENV, `APPROVED_SHA=${approvedSha}\n`);
@@ -48,7 +48,7 @@ jobs:
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
           APPROVED_SHA=${{ env.APPROVED_SHA }}
           BASE_SHA=${{ github.event.pull_request.base.sha }}
-          
+
           if [ -z "$APPROVED_SHA" ] || git merge-base --is-ancestor $BASE_SHA $APPROVED_SHA
           then
             echo "No merges happened";

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -60,10 +60,10 @@ jobs:
               echo "An unclean merge happened";
             else
               echo "No unclean merges";
-              MERGE_COMMIT_MSG="Merge branch 'main' into ${GITHUB_REF##*/}";
+              MERGE_COMMIT_MSG="Merge branch 'main' into ${GITHUB_REF#refs/heads/}";
               PATH_LENGTH=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | wc -l);
-              NUM_MERGES=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | grep "${MERGE_COMMIT_MSG}" | wc -l);
-              
+              NUM_MERGES=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | grep "$MERGE_COMMIT_MSG" | wc -l);
+              echo reached here
               echo $PATH_LENGTH == $NUM_MERGES
               if (( $PATH_LENGTH == $NUM_MERGES ));
               then

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -12,15 +12,72 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2
-      - name: Skip checking merge commits
+      - name: Get hash of last approved commit
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const owner = context.payload.repository.owner.login;
+            const repo = context.payload.repository.name;
+            const pull_number = context.payload.pull_request.number;
+
+            const approvals = await github.pulls
+              .listReviews({ owner, repo, pull_number })
+              .then((response) =>
+                response.data
+                  .filter(r => r.user.type == 'User' && r.state == 'APPROVED')
+                  .sort((a, b) => a.id - b.id)
+              );
+
+            if (approvals.length == 0) {
+              console.log('No approvals given.');
+              return;
+            }
+            
+            const approval = approvals[0];
+            const commitHash = approval.commit_id;
+            console.log(`Last approved at commit ${commitHash} by ${approval.user.login}.`);
+            
+            // Set APPROVED_SHA environment variable
+            const fs = require('fs');
+            fs.appendFileSync(process.env.GITHUB_ENV, `APPROVED_SHA=${approvedSha}\n`);
+      - name: Check if there are only clean merges
         shell: bash
         run: |
+          set -x -v
           git fetch --all
-          if (($(git show --no-patch --format="%P" ${{ github.event.pull_request.head.sha }} | wc -l) > 1)); then
-            echo "merge_commit=true" >> $GITHUB_ENV;
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          APPROVED_SHA=${{ env.APPROVED_SHA }}
+          MAIN_SHA=$(git rev-parse main)
+          echo HEAD_SHA=$HEAD_SHA
+          echo APPROVED_SHA=$APPROVED_SHA
+          echo MAIN_SHA=$MAIN_SHA
+          
+          if git merge-base --is-ancestor $MAIN_SHA $APPROVED_SHA
+          then
+            echo "No merges happened";
+          else
+            echo "MERGE_HAPPENED=true" >> $GITHUB_ENV;
+            ANCESTOR_SHA=$(git merge-base $MAIN_SHA $HEAD_SHA)
+            if git merge-tree $ANCESTOR_SHA $APPROVED_SHA $MAIN_SHA | grep -q '^+<*\.our$'
+            then
+              echo "An unclean merge happened";
+            else
+              echo "No unclean merges";
+              MERGE_COMMIT_MSG="Merge branch 'main' into $(git name-rev --name-only $HEAD_SHA)";
+              PATH_LENGTH=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | wc -l);
+              NUM_MERGES=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | grep $MERGE_COMMIT_MSG);
+              
+              if (( $PATH_LENGTH == $NUM_MERGES ))
+              then
+                echo "Only clean merges have happened.";
+                echo "ONLY_CLEAN_MERGES=true" >> $GITHUB_ENV;
+              else
+                echo "Some non-merge commits have happened.";
+              fi
+            fi
           fi
       - name: Auto dismiss on major changes
-        if: ${{ env.merge_commit != 'true' }}
+        if: ${{ env.ONLY_CLEAN_MERGES != 'true' }}
         uses: actions/github-script@v4
         with:
           script: |

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -43,7 +43,6 @@ jobs:
       - name: Check if there are only clean merges since the last approval
         shell: bash
         run: |
-          set -x -v
           git fetch --all
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
           APPROVED_SHA=${{ env.APPROVED_SHA }}
@@ -62,7 +61,7 @@ jobs:
               echo "No unclean merges";
               MERGE_COMMIT_MSG="Merge branch 'main' into ${GITHUB_REF##*/}";
               PATH_LENGTH=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | wc -l);
-              NUM_MERGES=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | grep "${MERGE_COMMIT_MSG}");
+              NUM_MERGES=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | grep "${MERGE_COMMIT_MSG}" | wc -l);
               
               if (( $PATH_LENGTH == $NUM_MERGES ))
               then

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -40,7 +40,7 @@ jobs:
             // Set APPROVED_SHA environment variable
             const fs = require('fs');
             fs.appendFileSync(process.env.GITHUB_ENV, `APPROVED_SHA=${approvedSha}\n`);
-      - name: Check if there are only clean merges
+      - name: Check if there are only clean merges since the last approval
         shell: bash
         run: |
           set -x -v
@@ -51,8 +51,7 @@ jobs:
           echo HEAD_SHA=$HEAD_SHA
           echo APPROVED_SHA=$APPROVED_SHA
           echo MAIN_SHA=$MAIN_SHA
-          
-          if git merge-base --is-ancestor $MAIN_SHA $APPROVED_SHA
+          if [ -z "$APPROVED_SHA" ] || git merge-base --is-ancestor $MAIN_SHA $APPROVED_SHA
           then
             echo "No merges happened";
           else

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            set -v
             const owner = context.payload.repository.owner.login;
             const repo = context.payload.repository.name;
             const pull_number = context.payload.pull_request.number;
@@ -44,6 +43,7 @@ jobs:
       - name: Check if there are only clean merges since the last approval
         shell: bash
         run: |
+          set -v
           git fetch --all
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
           APPROVED_SHA=${{ env.APPROVED_SHA }}

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Check if there are only clean merges since the last approval
         shell: bash
         run: |
-          set -v
+          set -v -x
           git fetch --all
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
           APPROVED_SHA=${{ env.APPROVED_SHA }}

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -48,9 +48,7 @@ jobs:
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
           APPROVED_SHA=${{ env.APPROVED_SHA }}
           BASE_SHA=${{ github.event.pull_request.base.sha }}
-          echo HEAD_SHA=$HEAD_SHA
-          echo APPROVED_SHA=$APPROVED_SHA
-          echo BASE_SHA=$BASE_SHA
+          
           if [ -z "$APPROVED_SHA" ] || git merge-base --is-ancestor $BASE_SHA $APPROVED_SHA
           then
             echo "No merges happened";

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -60,9 +60,9 @@ jobs:
               echo "An unclean merge happened";
             else
               echo "No unclean merges";
-              MERGE_COMMIT_MSG="Merge branch 'main' into $(git name-rev --name-only $HEAD_SHA)";
+              MERGE_COMMIT_MSG="Merge branch 'main' into ${GITHUB_REF##*/}";
               PATH_LENGTH=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | wc -l);
-              NUM_MERGES=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | grep $MERGE_COMMIT_MSG);
+              NUM_MERGES=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | grep "${MERGE_COMMIT_MSG}");
               
               if (( $PATH_LENGTH == $NUM_MERGES ))
               then

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -39,7 +39,7 @@ jobs:
 
             // Set APPROVED_SHA environment variable
             const fs = require('fs');
-            fs.appendFileSync(process.env.GITHUB_ENV, `APPROVED_SHA=${approvedSha}\n`);
+            fs.appendFileSync(process.env.GITHUB_ENV, `APPROVED_SHA=${commitHash}\n`);
       - name: Check if there are only clean merges since the last approval
         shell: bash
         run: |

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -47,17 +47,17 @@ jobs:
           git fetch --all
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
           APPROVED_SHA=${{ env.APPROVED_SHA }}
-          MAIN_SHA=$(git rev-parse origin/main)
+          BASE_SHA=${{ github.event.pull_request.base.sha }}
           echo HEAD_SHA=$HEAD_SHA
           echo APPROVED_SHA=$APPROVED_SHA
-          echo MAIN_SHA=$MAIN_SHA
-          if [ -z "$APPROVED_SHA" ] || git merge-base --is-ancestor $MAIN_SHA $APPROVED_SHA
+          echo BASE_SHA=$BASE_SHA
+          if [ -z "$APPROVED_SHA" ] || git merge-base --is-ancestor $BASE_SHA $APPROVED_SHA
           then
             echo "No merges happened";
           else
             echo "MERGE_HAPPENED=true" >> $GITHUB_ENV;
-            ANCESTOR_SHA=$(git merge-base $MAIN_SHA $HEAD_SHA)
-            if git merge-tree $ANCESTOR_SHA $APPROVED_SHA $MAIN_SHA | grep -q '^+<*\.our$'
+            ANCESTOR_SHA=$(git merge-base $BASE_SHA $HEAD_SHA)
+            if git merge-tree $ANCESTOR_SHA $APPROVED_SHA $BASE_SHA | grep -q '^+<*\.our$'
             then
               echo "An unclean merge happened";
             else

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -47,7 +47,7 @@ jobs:
           git fetch --all
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
           APPROVED_SHA=${{ env.APPROVED_SHA }}
-          MAIN_SHA=$(git rev-parse main)
+          MAIN_SHA=$(git rev-parse origin/main)
           echo HEAD_SHA=$HEAD_SHA
           echo APPROVED_SHA=$APPROVED_SHA
           echo MAIN_SHA=$MAIN_SHA

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -64,7 +64,8 @@ jobs:
               PATH_LENGTH=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | wc -l);
               NUM_MERGES=$(git log --oneline --ancestry-path $APPROVED_SHA...$HEAD_SHA | grep "${MERGE_COMMIT_MSG}" | wc -l);
               
-              if (( $PATH_LENGTH == $NUM_MERGES ))
+              echo $PATH_LENGTH == $NUM_MERGES
+              if (( $PATH_LENGTH == $NUM_MERGES ));
               then
                 echo "Only clean merges have happened.";
                 echo "ONLY_CLEAN_MERGES=true" >> $GITHUB_ENV;


### PR DESCRIPTION
<!--- SUMMARIZE your changes in the Title above -->
<!--- Detail any specific changes here -->

## Motivation and Context

<!--- EXPLAIN why this change is required. -->
<!--- Link any relevant issues via "Fixes #" or "Helps with #". -->

It's annoying to see clean merges dismiss approvals. This checks to see whether there have only been clean merges since the last approved commit and prevents dismissal.

## How Has This Been Tested?

<!--- DESCRIBE in detail how you tested your changes. -->
<!--- Are these changes covered by new tests or existing tests? -->
<!--- How else did you test these changes? -->
Manually tried some of the commands in the terminal. Been running it against this PR. Will wait to merge until it's merged lots of changes from main before merging this one to make sure this actually works.
