### PR TITLE
Fix UserHome missing import bug

### DIFF
--- a/src/pages/UserHome.jsx
+++ b/src/pages/UserHome.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Helmet from 'react-helmet';
 import { AddCircle as AddIcon, Inbox as InboxIcon } from '@material-ui/icons';
 import { Link } from 'react-router-dom';
 import firebase from 'firebase';


### PR DESCRIPTION
If you log in to https://dreamscholars.org/ it's currently broken because of a missing import.