### PR TITLE
Scholarhip Form reset to initial section after submission

### DIFF
--- a/src/components/ScholarshipForm.jsx
+++ b/src/components/ScholarshipForm.jsx
@@ -79,6 +79,7 @@ function ScholarshipForm({ scholarship, submitFn, onSubmitError }) {
       scholarship
         .save()
         .then(submitFn)
+        .then(() => setActiveStep(0))
         .then(resetForm)
         .catch(onSubmitError)
         .finally(() => setSubmitting(false));


### PR DESCRIPTION
<!--- SUMMARIZE your changes in the Title above -->
<!--- Detail any specific changes here -->

## Motivation and Context

<!--- EXPLAIN why this change is required. -->
<!--- Link any relevant issues via "Fixes #" or "Helps with #". -->
Takes the user back to the initial section of the form once a scholarship is submitted. 
Will prevent user from submitting a scholarship with null values.

## How Has This Been Tested?
localhost
<!--- DESCRIBE in detail how you tested your changes. -->
<!--- Are these changes covered by new tests or existing tests? -->
<!--- How else did you test these changes? -->


## Types of changes

<!--- CHECK all the types of changes introduced by replacing "[ ]" with "[x]" in the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## Previewing Changes

<!--- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. --->

<!--- DETAIL the steps needed to preview your user visible changes. --->
<!--- Be very specific about what to look for and what things to try. --->

<!-- TODO: REPLACE "NUMBER" WITH THE PULL REQUEST NUMBER --->
<!-- The URL should match the URL left by render[bot]'s comment. --->

1. Go to https://s4us-pr-689.onrender.com/scholarships/new.
2. submit new scholarship
3. form should reset to initial section 

## Checklist:

<!--- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
