### PR TITLE
Fix emulator exec script to detect running process instead

### DIFF
--- a/scripts/emulators_exec.sh
+++ b/scripts/emulators_exec.sh
@@ -7,14 +7,16 @@ warn() {
   echo "${BOLD}${YELLOW}WARNING:${NORMAL} $1"
 }
 
-LOCK_FILE=.firebase-emulator.lock
-if [ -f "${LOCK_FILE}" ]; then
-  warn "Firestore emulators are already running!"
+if lsof -i tcp:8080; then
+  PID=$(lsof -t -i tcp:8080)
+  warn "Firestore emulator may already be running (PID: $PID)!"
   export FIRESTORE_EMULATOR_HOST='localhost:8080'
   $@ # expands and runs the given command args
-  warn "Firestore emulators may still be running!"
 else
-  touch "${LOCK_FILE}"
   firebase emulators:exec --only firestore,auth --ui --import=tmp/ --export-on-exit=tmp/ "$@" || exit 1
-  rm "${LOCK_FILE}"
+fi
+
+if lsof -i tcp:8080; then
+  PID=$(lsof -t -i tcp:8080)
+  warn "Firestore emulators may still be running (PID: $PID)!"
 fi


### PR DESCRIPTION
<!--- SUMMARIZE your changes in the Title above -->
<!--- Detail any specific changes here -->

## Motivation and Context

<!--- EXPLAIN why this change is required. -->
<!--- Link any relevant issues via "Fixes #" or "Helps with #". -->

If for some reason the lock file exists but the emulators aren't running you'll run into some issues. This'll instead check if there's already a process running on the Firestore emulator port and print the PID if so.

## How Has This Been Tested?

<!--- DESCRIBE in detail how you tested your changes. -->
<!--- Are these changes covered by new tests or existing tests? -->
<!--- How else did you test these changes? -->

Locally. 
