### PR TITLE
Add lint check for missing grade level requirements

### DIFF
--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -44,7 +44,7 @@ export function parseOutdatedSchoolPeriods(desc: string): string[] {
     .filter((s) => !s.includes(THIS_YEAR.toString()));
 }
 
-/** Parses the given description for ethnicities and returns matches. */
+/** Parses the given description for grade levels and returns matches. */
 export function parseGradeLevels(desc: string): GradeLevel[] {
   const lowerDesc = desc.toLowerCase();
   const keywords = {

--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -144,7 +144,7 @@ export function lint(scholarship: ScholarshipData): String[] {
   if (missingGrades.length) {
     issues.push(
       `Potentially missing grade level requirements: ${JSON.stringify(
-        missingGrades
+        missingGrades.map(GradeLevel.toString)
       )}`
     );
   }

--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -1,9 +1,11 @@
 /** Utility methods for linting scholarship information and detecting errors. */
 
 import AmountType from '../types/AmountType';
+import GradeLevel from '../types/GradeLevel';
 import ScholarshipAmount from '../types/ScholarshipAmount';
 import ScholarshipData from '../types/ScholarshipData';
 
+/** Custom match object to provide additional context outside of a value. */
 interface MatchInfo {
   /** Phrase where a value was detected. */
   phrase: string;
@@ -11,7 +13,7 @@ interface MatchInfo {
   value: string;
 }
 
-/** Parses the given description looking for a minimum GPA value. Returns a MatchInfo if found.*/
+/** Parses the given description looking for a minimum GPA value. Returns a MatchInfo if found. */
 export function parseMinGPA(desc: string): MatchInfo | null {
   if (
     desc.includes('GPA') ||
@@ -42,9 +44,61 @@ export function parseOutdatedSchoolPeriods(desc: string): string[] {
     .filter((s) => !s.includes(THIS_YEAR.toString()));
 }
 
+/** Parses the given description for ethnicities and returns matches. */
+export function parseGradeLevels(desc: string): GradeLevel[] {
+  const lowerDesc = desc.toLowerCase();
+  const keywords = {
+    [GradeLevel.MiddleSchool]: ['middle school', '[78]th grade'],
+    [GradeLevel.HsFreshman]: ['9th grade'],
+    [GradeLevel.HsSophomore]: ['10th grade'],
+    [GradeLevel.HsJunior]: ['11th grade', 'high school[^.]* junior'],
+    [GradeLevel.HsSenior]: ['12th grade', 'high school[^.]* senior'],
+    [GradeLevel.CollegeFreshman]: ['freshm[ae]n'],
+    [GradeLevel.CollegeSophomore]: ['sophomore'],
+    [GradeLevel.CollegeJunior]: ['(college|undergraduate)[^.]* junior'],
+    [GradeLevel.CollegeSenior]: ['(college|undergraduate)[^.]* senior'],
+    [GradeLevel.GraduateFirstYear]: ['graduate[^.]* (1st|first) year'],
+    [GradeLevel.GraduateSecondYear]: ['graduate[^.]* (2nd|second) year'],
+    [GradeLevel.GraduateThirdYear]: ['graduate[^.]* (3rd|third) year'],
+    [GradeLevel.GraduateFourthYear]: ['graduate[^.]* (4th|fouth) year'],
+    [GradeLevel.GraduateFifthYear]: ['graduate[^.]* (5th|fifth) year'],
+  };
+  const matches = new Set(
+    GradeLevel.keys().filter((g) =>
+      keywords[g].some((k) => lowerDesc.match(new RegExp(k)))
+    )
+  );
+
+  // Search for keywords belong to whole groups of students, ignoring them
+  // if we've already detected more specific grade levels for that group.
+  const { highSchoolers, undergrads, grads } = GradeLevel;
+  if (desc.match(/8(th)?-12(th)?/)) {
+    [GradeLevel.MiddleSchool, ...highSchoolers].forEach((g) => matches.add(g));
+  } else if (
+    desc.match(/9(th)?-12(th)?/) ||
+    lowerDesc.includes('high school student')
+  ) {
+    highSchoolers.forEach((g) => matches.add(g));
+  }
+
+  if (
+    !undergrads.some((g) => matches.has(g)) &&
+    desc.match(/(college (undergraduate|student)|undergraduate[^.]* student)/i)
+  ) {
+    undergrads.forEach((g) => matches.add(g));
+  }
+
+  if (!grads.some((g) => matches.has(g)) && desc.match(/\Wgraduate student/i)) {
+    grads.forEach((g) => matches.add(g));
+  }
+
+  return Array.from(matches);
+}
+
 /** Lints the given scholarship for mismatches and returns a list of errors as strings. */
 export function lint(scholarship: ScholarshipData): String[] {
   const { amount, description: desc, requirements: reqs } = scholarship;
+  const { grades } = reqs || {};
   const issues = [];
   const gpaMatch = parseMinGPA(desc);
 
@@ -82,6 +136,19 @@ export function lint(scholarship: ScholarshipData): String[] {
       );
     }
   }
+
+  // Look for potentially missing requirements
+  const missingGrades = parseGradeLevels(desc).filter(
+    (g) => !grades?.includes(g)
+  );
+  if (missingGrades.length) {
+    issues.push(
+      `Potentially missing grade level requirements: ${JSON.stringify(
+        missingGrades
+      )}`
+    );
+  }
+
   // TODO(#858): Detect more errors.
   return issues;
 }

--- a/src/models/Scholarships.test.ts
+++ b/src/models/Scholarships.test.ts
@@ -284,32 +284,9 @@ test('scholarships.list - filters by maxAmount', async () => {
 });
 
 const middleSchool = create({ grades: [GradeLevel.MiddleSchool] });
-const highSchool = create({
-  grades: [
-    GradeLevel.HsFreshman,
-    GradeLevel.HsSophomore,
-    GradeLevel.HsJunior,
-    GradeLevel.HsSenior,
-  ],
-});
-const college = create({
-  grades: [
-    GradeLevel.CollegeFreshman,
-    GradeLevel.CollegeSophomore,
-    GradeLevel.CollegeJunior,
-    GradeLevel.CollegeSenior,
-    GradeLevel.CollegeFifthYear,
-  ],
-});
-const graduate = create({
-  grades: [
-    GradeLevel.GraduateFirstYear,
-    GradeLevel.GraduateSecondYear,
-    GradeLevel.GraduateThirdYear,
-    GradeLevel.GraduateFourthYear,
-    GradeLevel.GraduateFifthYear,
-  ],
-});
+const highSchool = create({ grades: GradeLevel.highSchoolers });
+const college = create({ grades: GradeLevel.undergrads });
+const graduate = create({ grades: GradeLevel.grads });
 const gradeScholarships = [middleSchool, highSchool, college, graduate];
 
 test('scholarships.list - filters by grades (middle & high school)', async () => {
@@ -336,7 +313,7 @@ test('scholarships.list - filters by grades (all grades)', async () => {
     grades: [
       GradeLevel.MiddleSchool,
       GradeLevel.HsJunior,
-      GradeLevel.CollegeFifthYear,
+      GradeLevel.CollegeSenior,
       GradeLevel.GraduateThirdYear,
     ],
   });

--- a/src/types/Ethnicity.ts
+++ b/src/types/Ethnicity.ts
@@ -7,8 +7,8 @@ enum Ethnicity {
   White = 'WHITE',
 }
 
-const toStringMappings = {
-  [Ethnicity.AmericanIndianOrAlaskaNative]: 'American Indian or Alaska Native',
+const toStringMappings: Readonly<Record<Ethnicity, string>> = {
+  [Ethnicity.AmericanIndianOrAlaskaNative]: 'American Indian or Alaskan Native',
   [Ethnicity.Asian]: 'Asian',
   [Ethnicity.BlackOrAfricanAmerican]: 'Black or African American',
   [Ethnicity.HispanicOrLatino]: 'Hispanic or Latino',
@@ -18,10 +18,12 @@ const toStringMappings = {
 };
 
 namespace Ethnicity {
-  export function values(): any {
+  export function keys(): Ethnicity[] {
+    return Object.keys(toStringMappings) as Ethnicity[];
+  }
+  export function values(): Record<Ethnicity, String> {
     return toStringMappings;
   }
-
   export function toString(ethnicity: Ethnicity): string {
     return toStringMappings[ethnicity];
   }

--- a/src/types/GradeLevel.ts
+++ b/src/types/GradeLevel.ts
@@ -8,7 +8,7 @@ enum GradeLevel {
   CollegeSophomore = 14,
   CollegeJunior = 15,
   CollegeSenior = 16,
-  CollegeFifthYear = 17,
+  // DEPRECATED: CollegeFifthYear = 17,
   GraduateFirstYear = 18,
   GraduateSecondYear = 19,
   GraduateThirdYear = 20,
@@ -16,17 +16,17 @@ enum GradeLevel {
   GraduateFifthYear = 22,
 }
 
-const toStringMappings = {
-  [GradeLevel.MiddleSchool]: 'Middle School',
-  [GradeLevel.HsFreshman]: 'High School Freshman',
-  [GradeLevel.HsSophomore]: 'High School Sophomore',
-  [GradeLevel.HsJunior]: 'High School Junior',
-  [GradeLevel.HsSenior]: 'High School Senior',
+const toStringMappings: Readonly<Record<GradeLevel, string>> = {
+  [GradeLevel.MiddleSchool]: '8th Grade or earlier',
+  [GradeLevel.HsFreshman]: '9th Grade',
+  [GradeLevel.HsSophomore]: '10th Grade',
+  [GradeLevel.HsJunior]: '11th Grade',
+  [GradeLevel.HsSenior]: '12th Grade (High School Senior)',
   [GradeLevel.CollegeFreshman]: 'College Freshman',
   [GradeLevel.CollegeSophomore]: 'College Sophomore',
   [GradeLevel.CollegeJunior]: 'College Junior',
   [GradeLevel.CollegeSenior]: 'College Senior',
-  [GradeLevel.CollegeFifthYear]: 'College 5th Year',
+  // DEPRECATED: [GradeLevel.CollegeFifthYear]: 'College 5th Year',
   [GradeLevel.GraduateFirstYear]: 'Graduate 1st Year',
   [GradeLevel.GraduateSecondYear]: 'Graduate 2nd Year',
   [GradeLevel.GraduateThirdYear]: 'Graduate 3rd Year',
@@ -35,17 +35,37 @@ const toStringMappings = {
 };
 
 namespace GradeLevel {
-  export function keys(): any {
-    return Object.keys(toStringMappings).map((k) => parseInt(k));
+  export function keys(): GradeLevel[] {
+    return Object.keys(toStringMappings).map((k) => parseInt(k) as GradeLevel);
   }
-
-  export function values(): any {
+  export function values(): Record<GradeLevel, String> {
     return toStringMappings;
   }
-
   export function toString(level: GradeLevel): string {
     return toStringMappings[level];
   }
+
+  export const highSchoolers = [
+    GradeLevel.HsFreshman,
+    GradeLevel.HsSophomore,
+    GradeLevel.HsJunior,
+    GradeLevel.HsSenior,
+  ];
+
+  export const undergrads = [
+    GradeLevel.CollegeFreshman,
+    GradeLevel.CollegeSophomore,
+    GradeLevel.CollegeJunior,
+    GradeLevel.CollegeSenior,
+  ];
+
+  export const grads = [
+    GradeLevel.GraduateFirstYear,
+    GradeLevel.GraduateSecondYear,
+    GradeLevel.GraduateThirdYear,
+    GradeLevel.GraduateFourthYear,
+    GradeLevel.GraduateFifthYear,
+  ];
 }
 
 export default GradeLevel;


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->
Also tidied up GradeLevel and Ethnicity a bit so that:
- 5th year option is commented out (couldn't find this in our scholarship sheet)
- GradeLevel now has a variable for certain school levels
- GradeLevel string representation better represent the strings I found in our scholarship sheet.
- Each have correctly typed `keys()` and `values()` methods.

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

Helps with #858.

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [x] Existing or new tests cover my changes.
- [x] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
1. Try looking for creating a scholarship with grade level requirements.
1. Look for errors on the card.

## Screenshots

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- ATTACH screenshots for user visible changes. -->

<img width="1203" alt="Screen Shot 2022-01-16 at 5 28 19 PM" src="https://user-images.githubusercontent.com/8023233/149687220-76d58304-c2b7-4eab-8c54-64d31f8c71a3.png">

