### PR TITLE
Add lint checks for deadline and bullet points in single line descriptions

### DIFF
--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -182,20 +182,18 @@ export function lint(scholarship: ScholarshipData): String[] {
     );
   }
   const dateMatches =
-    desc
-      .match(dateRe)
-      ?.filter((d) => Date.parse(d) !== Number.NaN)
-      .map((d) =>
-        // This logic adds the current year to the end of the string in case it's missing.
-        d.includes(THIS_YEAR.toString()) || d.endsWith(`/${THIS_YEAR - 2000}`)
-          ? d
-          : d.includes('/')
-          ? `${d}/${THIS_YEAR - 2000}`
-          : `${d} ${THIS_YEAR}`
-      ) || [];
+    desc.match(dateRe)?.filter((d) => Date.parse(d) !== Number.NaN) || [];
   if (
     dateMatches?.length > 0 &&
     !dateMatches
+      .map((d) =>
+        // For MM/DD matches add the year if missing.
+        d.includes('/') && !d.match(/\d+\/\d+\/\d+/) ? d : `${d}/${THIS_YEAR}`
+      )
+      .map((d) =>
+        // For MM DD matches add the year if missing.
+        !d.includes('/') && !d.match(/(,? \d{4})/) ? d : `${d}, ${THIS_YEAR}`
+      )
       .map((d) => new Date(d).toLocaleDateString())
       .includes(deadline.toLocaleDateString())
   ) {

--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -188,11 +188,11 @@ export function lint(scholarship: ScholarshipData): String[] {
     !dateMatches
       .map((d) =>
         // For MM/DD matches add the year if missing.
-        d.includes('/') && !d.match(/\d+\/\d+\/\d+/) ? d : `${d}/${THIS_YEAR}`
+        d.includes('/') && !d.match(/\d+\/\d+\/\d+/) ? `${d}/${THIS_YEAR}` : d
       )
       .map((d) =>
         // For MM DD matches add the year if missing.
-        !d.includes('/') && !d.match(/(,? \d{4})/) ? d : `${d}, ${THIS_YEAR}`
+        !d.includes('/') && !d.match(/(,? \d{4})/) ? `${d}, ${THIS_YEAR}` : d
       )
       .map((d) => new Date(d).toLocaleDateString())
       .includes(deadline.toLocaleDateString())

--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -200,7 +200,9 @@ export function lint(scholarship: ScholarshipData): String[] {
       .includes(deadline.toLocaleDateString())
   ) {
     issues.push(
-      `Deadline specified is ${deadline.toLocaleDateString()} but other dates were found: ${dateMatches}.`
+      `Deadline specified is ${deadline.toLocaleDateString()} but other dates were found: ${JSON.stringify(
+        dateMatches
+      )}.`
     );
   }
   const gpaMatch = parseMinGPA(desc);


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

Fixes #858 

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [x] Existing or new tests cover my changes.
- [x] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
1. Try creating a scholarship with a conflicting deadline as the description or containing a single line descriptions with ` -` items.
2. Look for errors on the card.

## Screenshots

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- ATTACH screenshots for user visible changes. -->
<img width="775" alt="Screen Shot 2022-01-23 at 9 54 38 PM" src="https://user-images.githubusercontent.com/8023233/150729369-2376b22d-b85c-4aa5-884d-16a780a5bea7.png">

