### PR TITLE
Make ShareDialog encapsulate sharing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,6 @@ import { BRAND_NAME } from './config/constants';
 import FirebaseProvider from './lib/FirebaseProvider';
 import ProtectedRoute from './components/ProtectedRoute';
 import LoginDialog from './components/LoginDialog';
-import ShareDialog from './components/ShareDialog';
 
 function App() {
   return (
@@ -53,7 +52,6 @@ function App() {
               <Route path="/" element={<Home />} />
             </Routes>
             <LoginDialog />
-            <ShareDialog />
             <Footer />
           </Router>
         </ThemeProvider>

--- a/src/components/ScholarshipCard.jsx
+++ b/src/components/ScholarshipCard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import firebase from 'firebase';
 import PropTypes from 'prop-types';
 import {
@@ -28,10 +28,10 @@ import {
 } from '@mui/icons-material';
 import { genMailToLink, withDeviceInfo } from '../lib/mail';
 import ScholarshipAmount from '../types/ScholarshipAmount';
-import { BRAND_NAME } from '../config/constants';
 import Ethnicity from '../types/Ethnicity';
 import GradeLevel from '../types/GradeLevel';
 import { lint } from '../lib/lint';
+import ShareDialog from './ShareDialog';
 
 const DetailCardCell = ({ label, text }) => (
   <>
@@ -53,7 +53,6 @@ DetailCardCell.propTypes = {
 };
 
 export default function ScholarshipCard({ scholarship, style }) {
-  const navigate = useNavigate();
   const {
     name,
     organization,
@@ -68,30 +67,7 @@ export default function ScholarshipCard({ scholarship, style }) {
   const detailed = style !== 'result';
   const preview = style === 'preview';
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-  const shareFn = () => {
-    const URL = `https://${window.location.hostname}/scholarships/${scholarship.id}`;
-    const data = {
-      title: `${ScholarshipAmount.toString(amount)} - ${name} | ${BRAND_NAME}`,
-      text: `${ScholarshipAmount.toString(amount)}
-       - ${name} | ${BRAND_NAME} \n ${deadline?.toLocaleDateString()}\n`,
-      url: URL,
-    };
-
-    if (navigator.share) {
-      navigator
-        .share(data)
-        // eslint-disable-next-line no-console
-        .then(() => console.log('Thanks for sharing!'))
-        // eslint-disable-next-line no-console
-        .catch(console.error);
-    } else {
-      navigate('', {
-        replace: true,
-        state: { showShareDialog: true, shareData: data },
-      });
-    }
-  };
+  const [showShare, setShowShare] = useState(false);
 
   const currentUser = firebase.auth().currentUser;
   const [canEdit, setCanEdit] = useState(
@@ -174,7 +150,7 @@ export default function ScholarshipCard({ scholarship, style }) {
               <Button
                 variant="outlined"
                 startIcon={<ShareIcon />}
-                onClick={shareFn}
+                onClick={() => setShowShare(true)}
                 disabled={scholarship.id === undefined}>
                 Share
               </Button>
@@ -284,6 +260,13 @@ export default function ScholarshipCard({ scholarship, style }) {
             ))}
           </Box>
         </Alert>
+      )}
+      {detailed && (
+        <ShareDialog
+          open={showShare}
+          onClose={() => setShowShare(false)}
+          scholarship={scholarship}
+        />
       )}
     </Card>
   );

--- a/src/components/ShareDialog.jsx
+++ b/src/components/ShareDialog.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import React, { useEffect } from 'react';
 import {
   Button,
   Dialog,
@@ -20,22 +19,35 @@ import {
   TwitterIcon,
   TwitterShareButton,
 } from 'react-share';
+import { BRAND_NAME } from '../config/constants';
+import ScholarshipAmount from '../types/ScholarshipAmount';
 
-export default function ShareDialog() {
-  const location = useLocation();
+export default function ShareDialog({ scholarship, open, onClose }) {
+  const { amount, deadline, name } = scholarship.data;
 
-  const showShareDialog = location.state?.showShareDialog ?? false;
-  const shareData = location.state?.shareData ?? {};
-  const { title, url } = shareData;
+  const url = `https://${window.location.hostname}/scholarships/${scholarship.id}`;
+  const title = `${ScholarshipAmount.toString(
+    amount
+  )} - ${name} | ${BRAND_NAME}`;
+  const text = `${title}\n ${deadline?.toLocaleDateString()}\n`;
 
-  const navigate = useNavigate();
-  const closeDialog = () =>
-    navigate('', { replace: true, state: { shareData } });
+  console.log('rerendering share');
+  useEffect(() => {
+    if (open && navigator.share) {
+      onClose();
+      navigator
+        .share({ url, title, text })
+        // eslint-disable-next-line no-console
+        .then(() => console.log('Thanks for sharing!'))
+        // eslint-disable-next-line no-console
+        .catch(console.error);
+    }
+  }, [open, onClose, text, title, url]);
 
   return (
     <Dialog
-      open={showShareDialog}
-      onClose={closeDialog}
+      open={open && !navigator.share}
+      onClose={onClose}
       sx={{ textAlign: 'center' }}>
       <DialogTitle
         sx={{ color: 'background.paper', bgcolor: 'background.secondary' }}>

--- a/src/components/ShareDialog.jsx
+++ b/src/components/ShareDialog.jsx
@@ -31,7 +31,6 @@ export default function ShareDialog({ scholarship, open, onClose }) {
   )} - ${name} | ${BRAND_NAME}`;
   const text = `${title}\n ${deadline?.toLocaleDateString()}\n`;
 
-  console.log('rerendering share');
   useEffect(() => {
     if (open && navigator.share) {
       onClose();


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

It's a bit wonky how this was used (relying on history state) and how a lot of the sharing logic is outside of it. I've made changes so that now:
- It's fully controlled by the parent component
- The ShareDialog encapsulates handling native device sharing  

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Existing or new tests cover my changes.
- [x] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
1. Try sharing a scholarship
