### PR TITLE
Shorten under construction alert

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,7 +3,6 @@ import { Link, useLocation } from 'react-router-dom';
 import {
   AppBar,
   Alert,
-  AlertTitle,
   Avatar,
   Button,
   Grow,
@@ -42,11 +41,10 @@ const UnderConstructionAlert = ({ t }) => (
   <Alert
     severity="warning"
     action={
-      <Button component={MuiLink} href={SUBSCRIPTION_FORM_URL}>
+      <Button component={MuiLink} href={SUBSCRIPTION_FORM_URL} size="small">
         {t('btn.subscribeForUpdates')}
       </Button>
     }>
-    <AlertTitle>{t('alert.warning')}</AlertTitle>
     {t('constructAlert.description')}
   </Alert>
 );

--- a/src/i18n/translations/english.json
+++ b/src/i18n/translations/english.json
@@ -11,11 +11,11 @@
     "addScholarship": "Add a Scholarship",
     "login": "Login",
     "loadMore": "Load More",
-    "subscribeForUpdates": "Subscribe for updates"
+    "subscribeForUpdates": "Subscribe"
   },
 
   "constructAlert": {
-    "description": "🚧 Website Actively Under-Construction! 🚧"
+    "description": "Website under construction! 🚧"
   },
 
   "contact": {

--- a/src/i18n/translations/spanish.json
+++ b/src/i18n/translations/spanish.json
@@ -11,11 +11,11 @@
     "addScholarship": "Agregar una Beca",
     "login": "Iniciar sesión",
     "loadMore": "carga más",
-    "subscribeForUpdates": "Suscríbete para recibir actualizaciones"
+    "subscribeForUpdates": "Suscribir"
   },
 
   "constructAlert": {
-    "description": "🚧 ¡Sitio web bajo construcción! 🚧"
+    "description": "¡Sitio web bajo construcción! 🚧"
   },
 
   "contact": {

--- a/src/i18n/translations/spanish.json
+++ b/src/i18n/translations/spanish.json
@@ -15,7 +15,7 @@
   },
 
   "constructAlert": {
-    "description": "¡Sitio web bajo construcción! 🚧"
+    "description": "¡Sitio bajo construcción! 🚧"
   },
 
   "contact": {


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

Our "Website under construction" alert is pretty tall and wordy so it ends up taking up valuable screen height on small screens in both landscape and portrait mode (sample below is iPhone 5 SE):
<img width="500" alt="Screen Shot 2022-02-02 at 11 48 02 PM" src="https://user-images.githubusercontent.com/8023233/152301811-eef55db5-7114-40cb-8419-ba661f8c2b6a.png">
<img width="250" alt="Screen Shot 2022-02-02 at 11 50 20 PM" src="https://user-images.githubusercontent.com/8023233/152302083-1e743de0-8f81-4591-81c2-74a30a125307.png">

This change reduces that by removing the title (which is already redundant with the color/icon) and shortening the message.

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Existing or new tests cover my changes.
- [x] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
1. Notice the thinner alert at the top compare to the one currently live at dreamscholars.org.

## Screenshots

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- ATTACH screenshots for user visible changes. -->
<img width="500" alt="Screen Shot 2022-02-02 at 11 52 57 PM" src="https://user-images.githubusercontent.com/8023233/152302446-bfbb032e-fa2f-4787-bec7-f9c8becd971e.png">

<img width="250" alt="Screen Shot 2022-02-02 at 11 52 15 PM" src="https://user-images.githubusercontent.com/8023233/152302381-c5c06396-55af-420c-a7d1-1e5cac09ef7b.png">
