### PR TITLE
Fix comma issue when linting amounts

### DIFF
--- a/src/lib/lint.test.ts
+++ b/src/lib/lint.test.ts
@@ -222,6 +222,7 @@ describe('lint()', () => {
       [range500to1000, 'nor if range mentions no $ amount'],
       [max1000, 'nor if max only mentions max $1000 amount'],
       [min1000, 'nor if min only mentions min $1000 amount'],
+      [min1000, 'nor if min only mentions $1,000 with a comma'],
     ].forEach(([a, d]) =>
       expect(
         lint({

--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -167,12 +167,13 @@ export function lint(scholarship: ScholarshipData): String[] {
       'Decription is a single line but contains several "-" characters. Should those be separate lines?'
     );
   }
-  const amountMatches = desc.match(/\$[0-9,]+/g) || [];
+  const amountMatches =
+    desc.match(/\$[0-9,]+/g)?.map((s) => s.replace(',', '')) || [];
   if (
     amountMatches.length &&
     (amount.type === AmountType.Fixed || amount.type === AmountType.Varies) &&
-    ((amount.min && !desc.includes(amount.min.toString())) ||
-      (amount.max && !desc.includes(amount.max.toString())))
+    ((amount.min && !amountMatches.includes('$' + amount.min.toString())) ||
+      (amount.max && !amountMatches.includes('$' + amount.max.toString())))
   ) {
     const want = ScholarshipAmount.toString(amount);
     issues.push(


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

Addresses a slight bug introduced by #866 where amount strings with `,` in it are ignored:
<img width="880" alt="Screen Shot 2022-02-21 at 2 49 08 PM" src="https://user-images.githubusercontent.com/8023233/155035030-465db461-34a9-4484-80ad-b9583192d686.png">


## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [x] Existing or new tests cover my changes.
- [x] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
1. Look for or create a scholarship with amount `N` where `N >= 1000` but has `,` in the amount value in the description.
2. Ensure there are no lint errors about it.

## Screenshots

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- ATTACH screenshots for user visible changes. -->
Lint error for amount is now gone:

<img width="765" alt="Screen Shot 2022-02-21 at 2 51 54 PM" src="https://user-images.githubusercontent.com/8023233/155035210-6ce479ea-5382-4d93-afb4-aad8863e1124.png">


