### PR TITLE
Fix lint issue around substring matches for majors

### DIFF
--- a/src/lib/lint.test.ts
+++ b/src/lib/lint.test.ts
@@ -108,6 +108,9 @@ describe('parseMajors()', () => {
   test('does not detect unknown major', () => {
     expect(parseMajors('Welsh majors may apply')).toEqual([]);
   });
+  test('does not mis-detect substrings as majors', () => {
+    expect(parseMajors('Educational institutions')).toEqual([]);
+  });
 });
 
 describe('parseSchools()', () => {

--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -100,7 +100,9 @@ export function parseGradeLevels(desc: string): GradeLevel[] {
 /** Parses the given description for majors and returns the ones found. */
 export function parseMajors(desc: string): string[] {
   return Array.from(MAJORS).filter((m) =>
-    desc.toLowerCase().includes(m.toLowerCase())
+    desc
+      .toLowerCase()
+      .match(new RegExp('(\\W|^)' + m.toLowerCase() + '(\\W|$)'))
   );
 }
 


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

Helps with #931 .

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [x] Existing or new tests cover my changes.
- [ ] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
1. Look for or add a scholarship with a word in it that contains a major substring (e.g. `educational` for `education`)
2. Ensure it doesn't detect it as a missing major requirement.

## Screenshots

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- ATTACH screenshots for user visible changes. -->
