### PR TITLE
Lint improvements around grade level, major, and school

### DIFF
--- a/src/lib/lint.test.ts
+++ b/src/lib/lint.test.ts
@@ -65,11 +65,16 @@ describe('parseGradeLevels()', () => {
         GradeLevel.HsSenior,
       ],
       'graduating seniors from high school': [GradeLevel.HsSenior],
+      'seniors at Foo High School': [GradeLevel.HsSenior],
       'freshmen or sophomores': [
         GradeLevel.CollegeFreshman,
         GradeLevel.CollegeSophomore,
       ],
       'college seniors. undergraduate juniors': [
+        GradeLevel.CollegeJunior,
+        GradeLevel.CollegeSenior,
+      ],
+      'incoming junior or senior at UW': [
         GradeLevel.CollegeJunior,
         GradeLevel.CollegeSenior,
       ],
@@ -112,18 +117,42 @@ describe('parseMajors()', () => {
   test('does not mis-detect substrings as majors', () => {
     expect(parseMajors('Educational institutions')).toEqual([]);
   });
+  test('filters out false positives', () => {
+    expect(parseMajors('Biology major pursuing higher education')).toEqual([
+      'Biology',
+    ]);
+  });
+  test('reduces education and history noise', () => {
+    expect(parseMajors('Strong advocate for education')).toEqual([]);
+    expect(parseMajors('Dr. So has a long history of...')).toEqual([]);
+  });
 });
 
 describe('parseSchools()', () => {
   test('detects known schools', () => {
     expect(
       parseSchools(
-        'Student attending Florida State University or Georgia Institute of Technology may apply'
+        'Student attending Florida State University or Georgia Institute of Technology may apply',
+        'site'
       ).map((s) => s.name)
     ).toEqual(['Florida State University', 'Georgia Institute of Technology']);
   });
+  test('detects acronyms for school sites', () => {
+    expect(
+      parseSchools(
+        'UT English majors may apply',
+        'http://utulsa.edu/some/path'
+      ).map((s) => s.name)
+    ).toEqual(['University of Tulsa']);
+    expect(
+      parseSchools(
+        'UT English majors may apply',
+        'http://utoledo.edu/some/path'
+      ).map((s) => s.name)
+    ).toEqual(['University of Toledo']);
+  });
   test('does not detect unknown school', () => {
-    expect(parseSchools('Oxford University students')).toEqual([]);
+    expect(parseSchools('Oxford University students', 'site')).toEqual([]);
   });
 });
 

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -2207,10 +2207,14 @@ export interface School {
   name: string;
   /** State where the college is located, e.g. `'AL'`. */
   state: string;
-  /** Website of the college e.g. `'http://yccd.edu'`. */
+  /** Website of the college e.g. `'yccd.edu'`. */
   website: string;
 }
 
 export const SCHOOLS: School[] = RAW_SCHOOLS.split('\n')
   .map((s) => s.split('\t'))
-  .map(([name, website, state]) => ({ name, state, website }));
+  .map(([name, website, state]) => ({
+    name,
+    state,
+    website: website.replace('http://', ''),
+  }));


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->
- Better detect some grade levels.
- Reduce noise around words like "history" and "education".
- Detect school if site and acronym present.

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

These were some of the improvements from the phase 2 update note doc.

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [x] Existing or new tests cover my changes.
- [ ] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

You can try the edge cases from the unit tests out! They're not perfect by any means but it should reduce some noise and improve some things.