### PR TITLE
Show requirements per line with show all button

### DIFF
--- a/src/components/ScholarshipCard.tsx
+++ b/src/components/ScholarshipCard.tsx
@@ -35,19 +35,43 @@ import ShareDialog from './ShareDialog';
 import useAuth from '../lib/useAuth';
 import ScholarshipData from '../types/ScholarshipData';
 
-const DetailCardCell = ({ label, text }: { label: string; text: string }) => (
-  <>
-    <Grid container justifyContent="space-between">
-      <Grid item xs={12} sm>
-        <Typography>{label}</Typography>
+const SHOW_MORE_THRESHOLD = 5;
+
+const DetailCardCell = ({
+  label,
+  values,
+}: {
+  label: string;
+  values: string[];
+}) => {
+  const [showAll, setShowAll] = useState(false);
+  const shownValues = showAll ? values : values.slice(0, SHOW_MORE_THRESHOLD);
+  return (
+    <>
+      <Grid container justifyContent="space-between">
+        <Grid item xs={12} sm>
+          <Typography>{label}</Typography>
+        </Grid>
+
+        <Grid item sx={{ textAlign: { sm: 'right' } }} xs={12} sm>
+          {values.length === 0
+            ? 'Any'
+            : shownValues.map((v) => <Typography>{v}</Typography>)}
+          {values.length > shownValues.length && (
+            <MuiLink
+              component={Button}
+              onClick={() => setShowAll(true)}
+              sx={{ p: 0 }}>
+              +{values.length - SHOW_MORE_THRESHOLD} more
+            </MuiLink>
+          )}
+        </Grid>
       </Grid>
-      <Grid item sx={{ textAlign: { sm: 'right' } }} xs={12} sm>
-        <Typography>{text}</Typography>
-      </Grid>
-    </Grid>
-    <Divider light sx={{ m: 1.5 }} />
-  </>
-);
+      <Divider light sx={{ m: 1.5 }} />
+    </>
+  );
+};
+DetailCardCell.defaultProps = { values: [] };
 
 export default function ScholarshipCard({
   scholarship,
@@ -67,9 +91,11 @@ export default function ScholarshipCard({
     website,
     description,
     tags,
-    requirements: reqs,
+    requirements,
     author,
   } = scholarship.data;
+  const { ethnicities, gpa, grades, majors, schools, states } =
+    requirements || {};
   const detailed = style !== 'result';
   const preview = style === 'preview';
 
@@ -189,42 +215,27 @@ export default function ScholarshipCard({
               </Typography>
               <DetailCardCell
                 label="State"
-                text={
-                  reqs?.states?.map(State.toString).sort().join(', ') || 'All'
-                }
+                values={states?.map(State.toString).sort()}
               />
               <DetailCardCell
                 label="GPA"
-                text={
-                  reqs?.gpa && Number.isInteger(reqs?.gpa)
-                    ? reqs.gpa.toFixed(1)
-                    : reqs?.gpa?.toString() || 'All'
+                values={
+                  (gpa && [
+                    Number.isInteger(gpa) ? gpa.toFixed(1) : gpa?.toString(),
+                  ]) ||
+                  undefined
                 }
               />
               <DetailCardCell
                 label="Grades"
-                text={
-                  reqs?.grades?.map(GradeLevel.toString).sort().join(', ') ||
-                  'All'
-                }
+                values={grades?.sort().map(GradeLevel.toString)}
               />
               <DetailCardCell
                 label="Demographic"
-                text={
-                  reqs?.ethnicities
-                    ?.map(Ethnicity.toString)
-                    .sort()
-                    .join(', ') || 'All'
-                }
+                values={ethnicities?.map(Ethnicity.toString).sort()}
               />
-              <DetailCardCell
-                label="Majors"
-                text={reqs?.majors?.sort().join(', ') || 'All'}
-              />
-              <DetailCardCell
-                label="Schools"
-                text={reqs?.schools?.sort().join(', ') || 'All'}
-              />
+              <DetailCardCell label="Majors" values={majors?.sort()} />
+              <DetailCardCell label="Schools" values={schools?.sort()} />
             </Box>
           )}
 


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

When dealing with a long list of values (e.g. majors, schools), it can difficult to quickly scan and find a specific value. This makes it so that the first 5 values are shown and you can click a **+N more** link to fully expand the list.

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Existing or new tests cover my changes.
- [x] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
1. Look for (or create) a scholarship with 6 or more majors or schools.
2. Check that the card shows first five and the rest can be expanded.

## Screenshots

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- ATTACH screenshots for user visible changes. -->

<img width="725" alt="Screen Shot 2022-04-04 at 8 07 50 PM" src="https://user-images.githubusercontent.com/8023233/161671148-7abe7aa2-b4f7-461b-a1a8-d040ed8e8a64.png">
