### PR TITLE
Support filtering state options by full name

### DIFF
--- a/src/components/ScholarshipForm.jsx
+++ b/src/components/ScholarshipForm.jsx
@@ -15,6 +15,7 @@ import {
   Stepper,
   Typography,
   FormHelperText,
+  createFilterOptions,
 } from '@mui/material';
 import PropTypes from 'prop-types';
 import validationSchema from '../validation/ValidationSchema';
@@ -243,7 +244,10 @@ function ScholarshipForm({ scholarship }) {
               id="requirements.states"
               labelStyle={labelStyle}
               options={STATES.map((s) => s.abbr)}
-              getOptionLabel={(option) => State.toString(option)}
+              getOptionLabel={(s) => State.toString(s)}
+              filterOptions={createFilterOptions({
+                stringify: (s) => State.toString(s),
+              })}
               formik={formik}
               placeholder="No state requirements"
             />


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

Currently you can only filter options by state abbreviations. This supports filtering by both since `State.toString()` contains both the state name and the state abbreviation.

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Existing or new tests cover my changes.
- [ ] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
1. Try creating/editing a scholarship
2. Try filtering a state by its abbreviation or name (e.g. `ME` and `Maine`)
3. Ensure the state you're looking for shows up

## Screenshots

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- ATTACH screenshots for user visible changes. -->
