### PR TITLE
Automatically add missing http prefix to website in scholarship form

### DIFF
--- a/src/components/ScholarshipForm.jsx
+++ b/src/components/ScholarshipForm.jsx
@@ -123,6 +123,13 @@ function ScholarshipForm({ scholarship }) {
               id="website"
               formik={formik}
               labelStyle={labelStyle}
+              placeholder="https://"
+              onBlur={(e) => {
+                // Automatically prepend https:// to the URL if the protocol is missing
+                if (!/https?:\/\//.test(e.target.value)) {
+                  formik.setFieldValue('website', 'https://' + e.target.value);
+                }
+              }}
             />
           </Grid>
           <Grid item sm={6}>


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

Fixes #1053 

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Existing or new tests cover my changes.
- [x] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
1. Either add or edit a scholarship
2. Try enter a website value without the `http://` or `https://` prefix.
3. Click away
4. Notice how `https://` is automatically prepended.