### PR TITLE
Expanded first filter accordion by default

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -55,6 +55,7 @@ export default function FilterPanel({ onClose }) {
       comp: <MajorFilter majors={majors} onChange={setMajors} />,
       changed:
         JSON.stringify(majors || []) !== JSON.stringify(params.majors || []),
+      expanded: true,
     },
     Amount: {
       comp: (
@@ -98,7 +99,7 @@ export default function FilterPanel({ onClose }) {
       </Toolbar>
 
       {Object.entries(filters).map(([name, filter]) => (
-        <Accordion key={name} disableGutters>
+        <Accordion key={name} disableGutters defaultExpanded={filter.expanded}>
           <AccordionSummary
             expandIcon={<ExpandMoreIcon />}
             aria-controls={name + '-content'}

--- a/src/components/MajorFilter.jsx
+++ b/src/components/MajorFilter.jsx
@@ -29,7 +29,6 @@ function MajorFilter({ majors, onChange }) {
           <OutlinedInput
             ref={params.InputProps.ref}
             inputProps={params.inputProps}
-            autoFocus
             placeholder={
               !limitReached ? 'Enter a major to filter by...' : 'Limit reached'
             }


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

Expands the major filter accordion by default

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Existing or new tests cover my changes.
- [ ] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
2. view scholarships
3. first filter accordion should be expanded 

## Screenshots

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- ATTACH screenshots for user visible changes. -->
