### PR TITLE
Downgrade CI node version to 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '18'
+          node-version: '16'
       - run: yarn install --frozen-lockfile
       - run: yarn build --frozen-lockfile
       - uses: w9jds/firebase-action@master


### PR DESCRIPTION
This seems to be the cause per https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported
