### PR TITLE
Improve sharing by adding titles/subjects

### DIFF
--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -40,8 +40,8 @@ export default function ShareDialog({
   const { amount, deadline, name } = scholarship.data;
   const { t } = useTranslation('common');
 
-  const url = `https://${window.location.hostname}/scholarships/${scholarship.id}`;
-  const title = `${ScholarshipAmount.toString(
+  const url = `${window.location.origin}/scholarships/${scholarship.id}`;
+  const title = `$${ScholarshipAmount.toString(
     amount
   )} - ${name} | ${BRAND_NAME}`;
   const text = `${title}\n ${deadline?.toLocaleDateString()}\n`;
@@ -78,30 +78,35 @@ export default function ShareDialog({
         <EmailShareButton
           beforeOnClick={() => logShare()('email')}
           url={url}
+          subject={title}
           style={{ margin: '4px' }}>
           <EmailIcon round />
         </EmailShareButton>
         <FacebookShareButton
           beforeOnClick={() => logShare()('facebook')}
           url={url}
+          quote={title}
           style={{ margin: '4px' }}>
           <FacebookIcon round />
         </FacebookShareButton>
         <TwitterShareButton
           beforeOnClick={() => logShare()('twitter')}
           url={url}
+          title={title}
           style={{ margin: '4px' }}>
           <TwitterIcon round />
         </TwitterShareButton>
         <LinkedinShareButton
           beforeOnClick={() => logShare()('linkedin')}
           url={url}
+          title={title}
           style={{ margin: '4px' }}>
           <LinkedinIcon round />
         </LinkedinShareButton>
         <RedditShareButton
           beforeOnClick={() => logShare()('reddit')}
           url={url}
+          title={title}
           style={{ margin: '4px' }}>
           <RedditIcon round />
         </RedditShareButton>


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

Just noticed when you click **Share** on a scholarship it only shares the link for whatever social media you click. We should _at least_ share a title too. Maybe we can even share a description too later.

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Existing or new tests cover my changes.
- [x] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
1. Find a scholarship and click on it.
2. Try sharing it via Email, Facebook, etc.
3. Make sure the title is there.
