### PR TITLE
Move Header and Footer out of content-wrap div

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,9 +49,9 @@ function App() {
               <ScholarshipsProvider>
                 <Router>
                   <ScrollToTop />
+                  <Header />
+                  <HeaderSkeleton />
                   <div className="content-wrap">
-                    <Header />
-                    <HeaderSkeleton />
                     <Suspense fallback={<LinearProgress sx={{ m: 5 }} />}>
                       <Routes>
                         <Route
@@ -80,10 +80,10 @@ function App() {
                         <Route path="/terms" element={<Terms />} />
                         <Route path="/" element={<Home />} />
                       </Routes>
-                      <Footer />
                       <LoginDialog />
                     </Suspense>
                   </div>
+                  <Footer />
                 </Router>
               </ScholarshipsProvider>
             </AuthProvider>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,8 +51,8 @@ function App() {
                   <ScrollToTop />
                   <Header />
                   <HeaderSkeleton />
-                  <div className="content-wrap">
-                    <Suspense fallback={<LinearProgress sx={{ m: 5 }} />}>
+                  <Suspense fallback={<LinearProgress sx={{ m: 5 }} />}>
+                    <div className="content-wrap">
                       <Routes>
                         <Route
                           path="/scholarships/new"
@@ -81,9 +81,12 @@ function App() {
                         <Route path="/" element={<Home />} />
                       </Routes>
                       <LoginDialog />
-                    </Suspense>
-                  </div>
-                  <Footer />
+                    </div>
+                    {/* Footer inside <Suspense> but outside <div> so it:
+                          1. Gravitates to the bottom (see App.css) and
+                          2. Doesn't appear before main content.*/}
+                    <Footer />
+                  </Suspense>
                 </Router>
               </ScholarshipsProvider>
             </AuthProvider>

--- a/src/pages/PublicHome.tsx
+++ b/src/pages/PublicHome.tsx
@@ -38,7 +38,7 @@ function PublicHome(): JSX.Element {
 
       <ScholarshipsMadeSimple />
 
-      <Box sx={{ background: (theme) => theme.palette.background.paper }}>
+      <Box sx={{ backgroundColor: 'background.paper', flex: 1 }}>
         <HomeSection
           alignItems="center"
           direction="row"

--- a/src/pages/PublicHome.tsx
+++ b/src/pages/PublicHome.tsx
@@ -38,7 +38,7 @@ function PublicHome(): JSX.Element {
 
       <ScholarshipsMadeSimple />
 
-      <Box sx={{ backgroundColor: 'background.paper', flex: 1 }}>
+      <Box sx={{ backgroundColor: 'background.paper' }}>
         <HomeSection
           alignItems="center"
           direction="row"


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->
This fixes two issues related to page load experience (#1102):
- `<Footer>` _should_ be outside of the content-wrap `<div>` so that the Flexbox container can push it away from content. I messed this up in a prior PR.
- But keep `<Footer>` _inside_ the same `<Suspense>` so it doesn't get rendered before the main content.

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Existing or new tests cover my changes.
- [x] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
2. Refresh the page (maybe with simulated slow speeds).
3. The footer should not appear before the main content
4. Zoom out the most you can.
5. The footer should stay at the very bottom.
6. Compare these behaviors with what we currently have at https://dreamscholars.org to see the difference.