### PR TITLE
Address --detectOpenHandles issue so test check runs faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "build": "react-scripts build",
     "start": "scripts/emulators_exec.sh 'react-scripts start'",
     "test": "scripts/emulators_exec.sh 'react-scripts test'",
-    "ci-test": "scripts/emulators_exec.sh 'react-scripts test --verbose --detectOpenHandles --coverage'",
+    "ci-test": "scripts/emulators_exec.sh 'react-scripts test --verbose --coverage'",
     "lint": "eslint --cache src/ --ext .js,.jsx,.ts,.tsx",
     "eject": "react-scripts eject",
     "prepare": "husky install"

--- a/src/firestore.rules.test.ts
+++ b/src/firestore.rules.test.ts
@@ -1,6 +1,3 @@
-/**
- * @jest-environment node
- */
 import {
   assertFails,
   assertSucceeds,

--- a/src/models/Scholarships.test.ts
+++ b/src/models/Scholarships.test.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment node
- */
-
 import { User } from 'firebase/auth';
 import {
   DocumentData,

--- a/src/models/base/FirestoreCollection.test.ts
+++ b/src/models/base/FirestoreCollection.test.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment node
- */
-
 import { FirestoreDataConverter } from 'firebase/firestore';
 import { initializeTestEnv } from '../../lib/testing';
 import FirestoreCollection from './FirestoreCollection';

--- a/src/models/base/FirestoreModel.test.ts
+++ b/src/models/base/FirestoreModel.test.ts
@@ -1,6 +1,3 @@
-/**
- * @jest-environment node
- */
 import {
   collection,
   doc,

--- a/src/models/base/FiretoreModelList.ts
+++ b/src/models/base/FiretoreModelList.ts
@@ -1,6 +1,3 @@
-/**
- * @jest-environment node
- */
 import FirestoreModel from './FirestoreModel';
 
 export default interface FirestoreModelList<E> {


### PR DESCRIPTION
<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context
Originally we added `--detectOpenHandles` because there were statements about it in the test runs. However, it never gives us anything useful. I did however track down that the tests that supposedly leak open handles are in `src/models`, particularly around interacting with Firestore (see #1174 for context).

Anyhow, it turns out the issue was the `@jest-environment node`. Removing that allows us to run `yarn test` without any complaints about leaked handles.

Also with this, the validation test check might be faster (at least it is on my machine).