### PR TITLE
refactor: decompose ScholarshipForm into step components

### DIFF
--- a/src/components/ScholarshipForm.tsx
+++ b/src/components/ScholarshipForm.tsx
@@ -1,36 +1,23 @@
 import React, { useContext, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useFormik } from 'formik';
 import {
   Alert,
   AlertTitle,
   Box,
   Button,
-  Checkbox,
-  FormControlLabel,
-  Grid,
+  Paper,
   Step,
   StepContent,
   StepLabel,
   Stepper,
   Typography,
-  FormHelperText,
-  createFilterOptions,
-  Paper,
   useMediaQuery,
   Theme,
 } from '@mui/material';
 import validationSchema from '../validation/ValidationSchema';
-import ScholarshipAmountField from './ScholarshipAmountField';
-import DeadlineField from './DeadlineField';
-import FormikTextField from './FormikTextField';
 import ScholarshipCard from './ScholarshipCard';
-import FormikMultiSelect from './FormikMultiSelect';
-import FormikAutocomplete from './FormikAutocomplete';
 import useOptionsData from '../lib/useOptionsData';
-import State, { STATES } from '../types/States';
-import { GradeLevelInfo } from '../types/GradeLevel';
-import { EthnicityInfo } from '../types/Ethnicity';
 import ScholarshipsContext from '../models/ScholarshipsContext';
 import { lintReqs, LintReqsResult } from '../lib/lint';
 import { useTranslation } from 'react-i18next';
@@ -38,8 +25,8 @@ import i18n from 'i18next';
 import ScholarshipData from '../types/ScholarshipData';
 import Model from '../models/base/Model';
 import ScholarshipEligibility from '../types/ScholarshipEligibility';
-
-const labelStyle = { marginBottom: 2 };
+import GeneralInfoStep from './scholarship-form/GeneralInfoStep';
+import EligibilityStep from './scholarship-form/EligibilityStep';
 
 interface SFProps {
   scholarship: Model<ScholarshipData>;
@@ -50,6 +37,7 @@ export default function ScholarshipForm({ scholarship }: SFProps): JSX.Element {
   const [submissionError, setSubmissionError] = useState(null as null | Error);
   const { invalidate } = useContext(ScholarshipsContext);
   const navigate = useNavigate();
+  const location = useLocation();
   const { majors: allMajors, schools: allSchools } = useOptionsData();
 
   const isDesktop = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
@@ -116,195 +104,18 @@ export default function ScholarshipForm({ scholarship }: SFProps): JSX.Element {
   const stepperItems = {
     [t('common:general')]: {
       description: t('generalDescription'),
-      content: (
-        <Grid container spacing={3}>
-          <Grid item sm={6} xs={12}>
-            <FormikTextField
-              label={`${t('scholarshipName')} *`}
-              id="name"
-              formik={formik}
-              labelStyle={labelStyle}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikTextField
-              label={t('organization')}
-              id="organization"
-              formik={formik}
-              labelStyle={labelStyle}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikTextField
-              label={`${t('scholarshipLink')} *`}
-              id="website"
-              formik={formik}
-              labelStyle={labelStyle}
-              placeholder="https://"
-              onBlur={(e) => {
-                // Automatically prepend https:// to the URL if the protocol is missing
-                if (!/https?:\/\//.test(e.target.value)) {
-                  formik.setFieldValue('website', 'https://' + e.target.value);
-                }
-              }}
-            />
-          </Grid>
-          <Grid item sm={6}>
-            <DeadlineField
-              label={`${t('deadline')} *`}
-              labelStyle={labelStyle}
-              formik={formik}
-            />
-          </Grid>
-          <Grid item>
-            <ScholarshipAmountField formik={formik} labelStyle={labelStyle} />
-          </Grid>
-          <Grid item xs={12}>
-            <FormikTextField
-              label={`${t('description')} *`}
-              id="description"
-              labelStyle={labelStyle}
-              formik={formik}
-              minRows={8}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikAutocomplete
-              label={t('tags')}
-              id="tags"
-              labelStyle={labelStyle}
-              freeSolo
-              formik={formik}
-              options={[]}
-              onChange={(e, vals) => {
-                const newVals = new Set(
-                  vals.map((v) => v.toLowerCase().replace(/\s+/g, '-')),
-                );
-                formik.setFieldValue('tags', Array.from(newVals));
-              }}
-              placeholder="E.g. athletics, daca, essay, stem, etc."
-            />
-          </Grid>
-        </Grid>
-      ),
+      content: <GeneralInfoStep formik={formik} />,
     },
     [t('eligibilityReqs')]: {
       description: t('requirementsDescription'),
       content: (
-        <Grid container spacing={3}>
-          <Grid item xs={12}>
-            {lintIssues?.messages?.length > 0 && (
-              <Alert severity="warning" sx={{ mt: 2 }}>
-                <AlertTitle>
-                  <strong>
-                    We found the following potential requirements in the
-                    description. Would you like to populate these values?
-                  </strong>
-                </AlertTitle>
-                <Box component="ul">
-                  {lintIssues.messages?.map((m, i) => (
-                    <Typography key={i} component="li">
-                      {m}
-                    </Typography>
-                  ))}
-                </Box>
-                <Button onClick={autoFill}>Autofill</Button>
-              </Alert>
-            )}
-          </Grid>
-          <Grid item xs={12}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={noReqsChecked}
-                  onChange={() =>
-                    formik.setFieldValue(
-                      'requirements',
-                      noReqsChecked ? undefined : {},
-                    )
-                  }
-                  color="primary"
-                />
-              }
-              label={t('noEligibilityReqs').toUpperCase()}
-            />
-            <FormHelperText error>{formik.errors.requirements}</FormHelperText>
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikMultiSelect
-              disabled={noReqsChecked}
-              label={t('grades')}
-              id="requirements.grades"
-              labelStyle={labelStyle}
-              formik={formik}
-              options={GradeLevelInfo.values()}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikTextField
-              id="requirements.gpa"
-              type="number"
-              disabled={noReqsChecked}
-              formik={formik}
-              label={t('minGpa')}
-              labelStyle={labelStyle}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikAutocomplete
-              disabled={noReqsChecked}
-              label={t('schools')}
-              id="requirements.schools"
-              labelStyle={labelStyle}
-              options={allSchools.map(
-                ({ name, state }) => `${name} (${state})`,
-              )}
-              freeSolo
-              formik={formik}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikAutocomplete
-              disabled={noReqsChecked}
-              label={t('states')}
-              id="requirements.states"
-              labelStyle={labelStyle}
-              options={STATES.map((s) => s.abbr)}
-              getOptionLabel={(s) => State.toString(s)}
-              filterOptions={createFilterOptions({
-                stringify: (s) => State.toString(s),
-              })}
-              formik={formik}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikAutocomplete
-              disabled={noReqsChecked}
-              label={t('majors')}
-              id="requirements.majors"
-              labelStyle={labelStyle}
-              options={allMajors}
-              freeSolo
-              formik={formik}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikMultiSelect
-              disabled={noReqsChecked}
-              label={t('ethnicity')}
-              id="requirements.ethnicities"
-              labelStyle={labelStyle}
-              formik={formik}
-              options={EthnicityInfo.values()}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-        </Grid>
+        <EligibilityStep
+          formik={formik}
+          lintIssues={lintIssues}
+          allMajors={allMajors}
+          allSchools={allSchools}
+          autoFill={autoFill}
+        />
       ),
     },
     [t('common:review')]: {

--- a/src/components/scholarship-form/EligibilityStep.tsx
+++ b/src/components/scholarship-form/EligibilityStep.tsx
@@ -1,6 +1,5 @@
-import React, { useContext, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useFormik } from 'formik';
+// Extracted from ScholarshipForm.tsx — Eligibility Requirements (step 2)
+import React from 'react';
 import {
   Alert,
   AlertTitle,
@@ -9,406 +8,155 @@ import {
   Checkbox,
   FormControlLabel,
   Grid,
-  Step,
-  StepContent,
-  StepLabel,
-  Stepper,
   Typography,
   FormHelperText,
   createFilterOptions,
-  Paper,
-  useMediaQuery,
-  Theme,
 } from '@mui/material';
-import validationSchema from '../validation/ValidationSchema';
-import ScholarshipAmountField from './ScholarshipAmountField';
-import DeadlineField from './DeadlineField';
-import FormikTextField from './FormikTextField';
-import ScholarshipCard from './ScholarshipCard';
-import FormikMultiSelect from './FormikMultiSelect';
-import FormikAutocomplete from './FormikAutocomplete';
-import useOptionsData from '../lib/useOptionsData';
-import State, { STATES } from '../types/States';
-import { GradeLevelInfo } from '../types/GradeLevel';
-import { EthnicityInfo } from '../types/Ethnicity';
-import ScholarshipsContext from '../models/ScholarshipsContext';
-import { lintReqs, LintReqsResult } from '../lib/lint';
+import FormikTextField from '../FormikTextField';
+import FormikMultiSelect from '../FormikMultiSelect';
+import FormikAutocomplete from '../FormikAutocomplete';
+import State, { STATES } from '../../types/States';
+import { GradeLevelInfo } from '../../types/GradeLevel';
+import { EthnicityInfo } from '../../types/Ethnicity';
+import { LintReqsResult } from '../../lib/lint';
 import { useTranslation } from 'react-i18next';
-import i18n from 'i18next';
-import ScholarshipData from '../types/ScholarshipData';
-import Model from '../models/base/Model';
-import ScholarshipEligibility from '../types/ScholarshipEligibility';
+import { School } from '../../types/options';
 
 const labelStyle = { marginBottom: 2 };
 
-interface SFProps {
-  scholarship: Model<ScholarshipData>;
+interface EligibilityStepProps {
+  formik: ReturnType<typeof import('formik').useFormik>;
+  lintIssues: LintReqsResult;
+  allMajors: string[];
+  allSchools: School[];
+  autoFill: () => void;
 }
 
-export default function ScholarshipForm({ scholarship }: SFProps): JSX.Element {
-  const [activeStep, setActiveStep] = useState(0);
-  const [submissionError, setSubmissionError] = useState(null as null | Error);
-  const { invalidate } = useContext(ScholarshipsContext);
-  const navigate = useNavigate();
-  const { majors: allMajors, schools: allSchools } = useOptionsData();
-
-  const isDesktop = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
-  const { t: validationT } = useTranslation('validation');
+export default function EligibilityStep({
+  formik,
+  lintIssues,
+  allMajors,
+  allSchools,
+  autoFill,
+}: EligibilityStepProps): JSX.Element {
   const { t } = useTranslation(['scholarships', 'common']);
-
-  const formik = useFormik({
-    initialValues: scholarship.data,
-    validationSchema: validationSchema(validationT),
-    validateOnChange: false,
-    onSubmit: (values, { setSubmitting }) => {
-      setSubmitting(true);
-      scholarship.data = { ...values };
-      scholarship
-        .save()
-        .then((s) => {
-          invalidate(s.id, s.data);
-          navigate(`/scholarships/${s.id}`, {
-            state: {
-              prevPath: location.pathname,
-              scholarship: { id: s.id, data: s.data },
-            },
-          });
-        })
-        .catch(setSubmissionError)
-        .finally(() => setSubmitting(false));
-    },
-  });
-
-  i18n.on('languageChanged', () => formik.setErrors({}));
-
-  const lintIssues: LintReqsResult =
-    activeStep === 1
-      ? lintReqs(formik.values, allMajors, allSchools)
-      : { messages: [], reqs: {} };
-  const autoFill = () => {
-    const vals = formik.values.requirements;
-    const lintVals = lintIssues.reqs;
-    const updatedReqs: ScholarshipEligibility = {};
-
-    const grades = [...(vals?.grades || []), ...(lintVals?.grades || [])];
-    const schools = [...(vals?.schools || []), ...(lintVals?.schools || [])];
-    const states = [...(vals?.states || []), ...(lintVals?.states || [])];
-    const majors = [...(vals?.majors || []), ...(lintVals?.majors || [])];
-    const ethnicities = [
-      ...(vals?.ethnicities || []),
-      ...(lintVals?.ethnicities || []),
-    ];
-
-    if (lintIssues.reqs.gpa) updatedReqs.gpa = lintVals.gpa;
-    if (grades.length) updatedReqs.grades = grades;
-    if (schools.length) updatedReqs.schools = schools;
-    if (states.length) updatedReqs.states = states;
-    if (majors.length) updatedReqs.majors = majors;
-    if (ethnicities.length) updatedReqs.ethnicities = ethnicities;
-
-    formik.setFieldValue('requirements', updatedReqs);
-  };
 
   // Initially requirements is null but is set to {} when the "no requirements"
   // checkbox is explicitly set.
   const noReqsChecked = JSON.stringify(formik.values.requirements) === '{}';
 
-  const stepperItems = {
-    [t('common:general')]: {
-      description: t('generalDescription'),
-      content: (
-        <Grid container spacing={3}>
-          <Grid item sm={6} xs={12}>
-            <FormikTextField
-              label={`${t('scholarshipName')} *`}
-              id="name"
-              formik={formik}
-              labelStyle={labelStyle}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikTextField
-              label={t('organization')}
-              id="organization"
-              formik={formik}
-              labelStyle={labelStyle}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikTextField
-              label={`${t('scholarshipLink')} *`}
-              id="website"
-              formik={formik}
-              labelStyle={labelStyle}
-              placeholder="https://"
-              onBlur={(e) => {
-                // Automatically prepend https:// to the URL if the protocol is missing
-                if (!/https?:\/\//.test(e.target.value)) {
-                  formik.setFieldValue('website', 'https://' + e.target.value);
-                }
-              }}
-            />
-          </Grid>
-          <Grid item sm={6}>
-            <DeadlineField
-              label={`${t('deadline')} *`}
-              labelStyle={labelStyle}
-              formik={formik}
-            />
-          </Grid>
-          <Grid item>
-            <ScholarshipAmountField formik={formik} labelStyle={labelStyle} />
-          </Grid>
-          <Grid item xs={12}>
-            <FormikTextField
-              label={`${t('description')} *`}
-              id="description"
-              labelStyle={labelStyle}
-              formik={formik}
-              minRows={8}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikAutocomplete
-              label={t('tags')}
-              id="tags"
-              labelStyle={labelStyle}
-              freeSolo
-              formik={formik}
-              options={[]}
-              onChange={(e, vals) => {
-                const newVals = new Set(
-                  vals.map((v) => v.toLowerCase().replace(/\s+/g, '-')),
-                );
-                formik.setFieldValue('tags', Array.from(newVals));
-              }}
-              placeholder="E.g. athletics, daca, essay, stem, etc."
-            />
-          </Grid>
-        </Grid>
-      ),
-    },
-    [t('eligibilityReqs')]: {
-      description: t('requirementsDescription'),
-      content: (
-        <Grid container spacing={3}>
-          <Grid item xs={12}>
-            {lintIssues?.messages?.length > 0 && (
-              <Alert severity="warning" sx={{ mt: 2 }}>
-                <AlertTitle>
-                  <strong>
-                    We found the following potential requirements in the
-                    description. Would you like to populate these values?
-                  </strong>
-                </AlertTitle>
-                <Box component="ul">
-                  {lintIssues.messages?.map((m, i) => (
-                    <Typography key={i} component="li">
-                      {m}
-                    </Typography>
-                  ))}
-                </Box>
-                <Button onClick={autoFill}>Autofill</Button>
-              </Alert>
-            )}
-          </Grid>
-          <Grid item xs={12}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={noReqsChecked}
-                  onChange={() =>
-                    formik.setFieldValue(
-                      'requirements',
-                      noReqsChecked ? undefined : {},
-                    )
-                  }
-                  color="primary"
-                />
-              }
-              label={t('noEligibilityReqs').toUpperCase()}
-            />
-            <FormHelperText error>{formik.errors.requirements}</FormHelperText>
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikMultiSelect
-              disabled={noReqsChecked}
-              label={t('grades')}
-              id="requirements.grades"
-              labelStyle={labelStyle}
-              formik={formik}
-              options={GradeLevelInfo.values()}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikTextField
-              id="requirements.gpa"
-              type="number"
-              disabled={noReqsChecked}
-              formik={formik}
-              label={t('minGpa')}
-              labelStyle={labelStyle}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikAutocomplete
-              disabled={noReqsChecked}
-              label={t('schools')}
-              id="requirements.schools"
-              labelStyle={labelStyle}
-              options={allSchools.map(
-                ({ name, state }) => `${name} (${state})`,
-              )}
-              freeSolo
-              formik={formik}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikAutocomplete
-              disabled={noReqsChecked}
-              label={t('states')}
-              id="requirements.states"
-              labelStyle={labelStyle}
-              options={STATES.map((s) => s.abbr)}
-              getOptionLabel={(s) => State.toString(s)}
-              filterOptions={createFilterOptions({
-                stringify: (s) => State.toString(s),
-              })}
-              formik={formik}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikAutocomplete
-              disabled={noReqsChecked}
-              label={t('majors')}
-              id="requirements.majors"
-              labelStyle={labelStyle}
-              options={allMajors}
-              freeSolo
-              formik={formik}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikMultiSelect
-              disabled={noReqsChecked}
-              label={t('ethnicity')}
-              id="requirements.ethnicities"
-              labelStyle={labelStyle}
-              formik={formik}
-              options={EthnicityInfo.values()}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-        </Grid>
-      ),
-    },
-    [t('common:review')]: {
-      description: isDesktop ? t('reviewOnRight') : t('reviewBelow'),
-      content: !isDesktop && (
-        <ScholarshipCard
-          scholarship={{ data: formik.values }}
-          style="preview"
-        />
-      ),
-    },
-  };
-
-  function validationCheck() {
-    const noReqsGiven =
-      !formik.values.requirements ||
-      Object.values(formik.values.requirements).every(
-        (val) => (Array.isArray(val) && val.length === 0) || val === '',
-      );
-    // no requirements & no checkbox fails
-    if (activeStep == 1 && !noReqsChecked && noReqsGiven)
-      return validationT('checkboxValid');
-
-    return '';
-  }
-
-  const onLastStep = activeStep == Object.keys(stepperItems).length - 1;
-
   return (
-    <Box
-      sx={{
-        display: isDesktop ? 'flex' : 'block',
-        alignItems: 'flex-start',
-      }}>
-      <Paper
-        elevation={2}
-        sx={{
-          p: { xs: 2, sm: 3 },
-          width: isDesktop ? '50%' : '100%',
-          mr: 2,
-        }}>
-        <form onSubmit={formik.handleSubmit}>
-          <Stepper activeStep={activeStep} orientation="vertical">
-            {Object.entries(stepperItems).map(
-              ([label, { description, content }]) => (
-                <Step key={label}>
-                  <StepLabel>{label}</StepLabel>
-                  <StepContent>
-                    <Typography>{description}</Typography>
-                    <Box marginY={3}>{content}</Box>
-                    <Button
-                      disabled={activeStep === 0}
-                      onClick={() => setActiveStep((prevStep) => prevStep - 1)}>
-                      {t('common:actions.back')}
-                    </Button>
-                    <Button
-                      key={activeStep}
-                      variant="contained"
-                      color="primary"
-                      disabled={formik.isSubmitting}
-                      type={onLastStep ? 'submit' : 'button'}
-                      onClick={() => {
-                        if (onLastStep) return;
-                        formik.validateForm().then((errors) => {
-                          const checkboxError = validationCheck();
-                          if (checkboxError)
-                            errors = { ...errors, requirements: checkboxError };
-
-                          if (Object.keys(errors).length === 0)
-                            setActiveStep((prevStep) => prevStep + 1);
-
-                          return formik.setErrors(errors);
-                        });
-                      }}>
-                      {onLastStep
-                        ? t('common:actions.submit')
-                        : t('common:actions.next')}
-                    </Button>
-                    {submissionError && (
-                      <Alert
-                        severity="error"
-                        onClose={() => setSubmissionError(null)}>
-                        <AlertTitle>
-                          There was an error submitting your changes:
-                        </AlertTitle>
-                        {submissionError.toString()}
-                      </Alert>
-                    )}
-                  </StepContent>
-                </Step>
-              ),
-            )}
-          </Stepper>
-        </form>
-      </Paper>
-
-      <Box sx={{ width: '50%' }}>
-        {isDesktop && (
-          <ScholarshipCard
-            scholarship={{ data: formik.values }}
-            style="preview"
-          />
+    <Grid container spacing={3}>
+      <Grid item xs={12}>
+        {lintIssues?.messages?.length > 0 && (
+          <Alert severity="warning" sx={{ mt: 2 }}>
+            <AlertTitle>
+              <strong>
+                We found the following potential requirements in the
+                description. Would you like to populate these values?
+              </strong>
+            </AlertTitle>
+            <Box component="ul">
+              {lintIssues.messages?.map((m, i) => (
+                <Typography key={i} component="li">
+                  {m}
+                </Typography>
+              ))}
+            </Box>
+            <Button onClick={autoFill}>Autofill</Button>
+          </Alert>
         )}
-      </Box>
-    </Box>
+      </Grid>
+      <Grid item xs={12}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={noReqsChecked}
+              onChange={() =>
+                formik.setFieldValue(
+                  'requirements',
+                  noReqsChecked ? undefined : {},
+                )
+              }
+              color="primary"
+            />
+          }
+          label={t('noEligibilityReqs').toUpperCase()}
+        />
+        <FormHelperText error>{formik.errors.requirements}</FormHelperText>
+      </Grid>
+      <Grid item sm={6} xs={12}>
+        <FormikMultiSelect
+          disabled={noReqsChecked}
+          label={t('grades')}
+          id="requirements.grades"
+          labelStyle={labelStyle}
+          formik={formik}
+          options={GradeLevelInfo.values()}
+          placeholder={t('noRequirements')}
+        />
+      </Grid>
+      <Grid item sm={6} xs={12}>
+        <FormikTextField
+          id="requirements.gpa"
+          type="number"
+          disabled={noReqsChecked}
+          formik={formik}
+          label={t('minGpa')}
+          labelStyle={labelStyle}
+          placeholder={t('noRequirements')}
+        />
+      </Grid>
+      <Grid item sm={6} xs={12}>
+        <FormikAutocomplete
+          disabled={noReqsChecked}
+          label={t('schools')}
+          id="requirements.schools"
+          labelStyle={labelStyle}
+          options={allSchools.map(({ name, state }) => `${name} (${state})`)}
+          freeSolo
+          formik={formik}
+          placeholder={t('noRequirements')}
+        />
+      </Grid>
+      <Grid item sm={6} xs={12}>
+        <FormikAutocomplete
+          disabled={noReqsChecked}
+          label={t('states')}
+          id="requirements.states"
+          labelStyle={labelStyle}
+          options={STATES.map((s) => s.abbr)}
+          getOptionLabel={(s) => State.toString(s)}
+          filterOptions={createFilterOptions({
+            stringify: (s) => State.toString(s),
+          })}
+          formik={formik}
+          placeholder={t('noRequirements')}
+        />
+      </Grid>
+      <Grid item sm={6} xs={12}>
+        <FormikAutocomplete
+          disabled={noReqsChecked}
+          label={t('majors')}
+          id="requirements.majors"
+          labelStyle={labelStyle}
+          options={allMajors}
+          freeSolo
+          formik={formik}
+          placeholder={t('noRequirements')}
+        />
+      </Grid>
+      <Grid item sm={6} xs={12}>
+        <FormikMultiSelect
+          disabled={noReqsChecked}
+          label={t('ethnicity')}
+          id="requirements.ethnicities"
+          labelStyle={labelStyle}
+          formik={formik}
+          options={EthnicityInfo.values()}
+          placeholder={t('noRequirements')}
+        />
+      </Grid>
+    </Grid>
   );
 }

--- a/src/components/scholarship-form/GeneralInfoStep.tsx
+++ b/src/components/scholarship-form/GeneralInfoStep.tsx
@@ -1,414 +1,92 @@
-import React, { useContext, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useFormik } from 'formik';
-import {
-  Alert,
-  AlertTitle,
-  Box,
-  Button,
-  Checkbox,
-  FormControlLabel,
-  Grid,
-  Step,
-  StepContent,
-  StepLabel,
-  Stepper,
-  Typography,
-  FormHelperText,
-  createFilterOptions,
-  Paper,
-  useMediaQuery,
-  Theme,
-} from '@mui/material';
-import validationSchema from '../validation/ValidationSchema';
-import ScholarshipAmountField from './ScholarshipAmountField';
-import DeadlineField from './DeadlineField';
-import FormikTextField from './FormikTextField';
-import ScholarshipCard from './ScholarshipCard';
-import FormikMultiSelect from './FormikMultiSelect';
-import FormikAutocomplete from './FormikAutocomplete';
-import useOptionsData from '../lib/useOptionsData';
-import State, { STATES } from '../types/States';
-import { GradeLevelInfo } from '../types/GradeLevel';
-import { EthnicityInfo } from '../types/Ethnicity';
-import ScholarshipsContext from '../models/ScholarshipsContext';
-import { lintReqs, LintReqsResult } from '../lib/lint';
+// Extracted from ScholarshipForm.tsx — General Info (step 1)
+import React from 'react';
+import { Grid } from '@mui/material';
+import FormikTextField from '../FormikTextField';
+import FormikAutocomplete from '../FormikAutocomplete';
+import DeadlineField from '../DeadlineField';
+import ScholarshipAmountField from '../ScholarshipAmountField';
 import { useTranslation } from 'react-i18next';
-import i18n from 'i18next';
-import ScholarshipData from '../types/ScholarshipData';
-import Model from '../models/base/Model';
-import ScholarshipEligibility from '../types/ScholarshipEligibility';
 
 const labelStyle = { marginBottom: 2 };
 
-interface SFProps {
-  scholarship: Model<ScholarshipData>;
+interface GeneralInfoStepProps {
+  formik: ReturnType<typeof import('formik').useFormik>;
 }
 
-export default function ScholarshipForm({ scholarship }: SFProps): JSX.Element {
-  const [activeStep, setActiveStep] = useState(0);
-  const [submissionError, setSubmissionError] = useState(null as null | Error);
-  const { invalidate } = useContext(ScholarshipsContext);
-  const navigate = useNavigate();
-  const { majors: allMajors, schools: allSchools } = useOptionsData();
-
-  const isDesktop = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
-  const { t: validationT } = useTranslation('validation');
+export default function GeneralInfoStep({
+  formik,
+}: GeneralInfoStepProps): JSX.Element {
   const { t } = useTranslation(['scholarships', 'common']);
 
-  const formik = useFormik({
-    initialValues: scholarship.data,
-    validationSchema: validationSchema(validationT),
-    validateOnChange: false,
-    onSubmit: (values, { setSubmitting }) => {
-      setSubmitting(true);
-      scholarship.data = { ...values };
-      scholarship
-        .save()
-        .then((s) => {
-          invalidate(s.id, s.data);
-          navigate(`/scholarships/${s.id}`, {
-            state: {
-              prevPath: location.pathname,
-              scholarship: { id: s.id, data: s.data },
-            },
-          });
-        })
-        .catch(setSubmissionError)
-        .finally(() => setSubmitting(false));
-    },
-  });
-
-  i18n.on('languageChanged', () => formik.setErrors({}));
-
-  const lintIssues: LintReqsResult =
-    activeStep === 1
-      ? lintReqs(formik.values, allMajors, allSchools)
-      : { messages: [], reqs: {} };
-  const autoFill = () => {
-    const vals = formik.values.requirements;
-    const lintVals = lintIssues.reqs;
-    const updatedReqs: ScholarshipEligibility = {};
-
-    const grades = [...(vals?.grades || []), ...(lintVals?.grades || [])];
-    const schools = [...(vals?.schools || []), ...(lintVals?.schools || [])];
-    const states = [...(vals?.states || []), ...(lintVals?.states || [])];
-    const majors = [...(vals?.majors || []), ...(lintVals?.majors || [])];
-    const ethnicities = [
-      ...(vals?.ethnicities || []),
-      ...(lintVals?.ethnicities || []),
-    ];
-
-    if (lintIssues.reqs.gpa) updatedReqs.gpa = lintVals.gpa;
-    if (grades.length) updatedReqs.grades = grades;
-    if (schools.length) updatedReqs.schools = schools;
-    if (states.length) updatedReqs.states = states;
-    if (majors.length) updatedReqs.majors = majors;
-    if (ethnicities.length) updatedReqs.ethnicities = ethnicities;
-
-    formik.setFieldValue('requirements', updatedReqs);
-  };
-
-  // Initially requirements is null but is set to {} when the "no requirements"
-  // checkbox is explicitly set.
-  const noReqsChecked = JSON.stringify(formik.values.requirements) === '{}';
-
-  const stepperItems = {
-    [t('common:general')]: {
-      description: t('generalDescription'),
-      content: (
-        <Grid container spacing={3}>
-          <Grid item sm={6} xs={12}>
-            <FormikTextField
-              label={`${t('scholarshipName')} *`}
-              id="name"
-              formik={formik}
-              labelStyle={labelStyle}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikTextField
-              label={t('organization')}
-              id="organization"
-              formik={formik}
-              labelStyle={labelStyle}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikTextField
-              label={`${t('scholarshipLink')} *`}
-              id="website"
-              formik={formik}
-              labelStyle={labelStyle}
-              placeholder="https://"
-              onBlur={(e) => {
-                // Automatically prepend https:// to the URL if the protocol is missing
-                if (!/https?:\/\//.test(e.target.value)) {
-                  formik.setFieldValue('website', 'https://' + e.target.value);
-                }
-              }}
-            />
-          </Grid>
-          <Grid item sm={6}>
-            <DeadlineField
-              label={`${t('deadline')} *`}
-              labelStyle={labelStyle}
-              formik={formik}
-            />
-          </Grid>
-          <Grid item>
-            <ScholarshipAmountField formik={formik} labelStyle={labelStyle} />
-          </Grid>
-          <Grid item xs={12}>
-            <FormikTextField
-              label={`${t('description')} *`}
-              id="description"
-              labelStyle={labelStyle}
-              formik={formik}
-              minRows={8}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikAutocomplete
-              label={t('tags')}
-              id="tags"
-              labelStyle={labelStyle}
-              freeSolo
-              formik={formik}
-              options={[]}
-              onChange={(e, vals) => {
-                const newVals = new Set(
-                  vals.map((v) => v.toLowerCase().replace(/\s+/g, '-')),
-                );
-                formik.setFieldValue('tags', Array.from(newVals));
-              }}
-              placeholder="E.g. athletics, daca, essay, stem, etc."
-            />
-          </Grid>
-        </Grid>
-      ),
-    },
-    [t('eligibilityReqs')]: {
-      description: t('requirementsDescription'),
-      content: (
-        <Grid container spacing={3}>
-          <Grid item xs={12}>
-            {lintIssues?.messages?.length > 0 && (
-              <Alert severity="warning" sx={{ mt: 2 }}>
-                <AlertTitle>
-                  <strong>
-                    We found the following potential requirements in the
-                    description. Would you like to populate these values?
-                  </strong>
-                </AlertTitle>
-                <Box component="ul">
-                  {lintIssues.messages?.map((m, i) => (
-                    <Typography key={i} component="li">
-                      {m}
-                    </Typography>
-                  ))}
-                </Box>
-                <Button onClick={autoFill}>Autofill</Button>
-              </Alert>
-            )}
-          </Grid>
-          <Grid item xs={12}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={noReqsChecked}
-                  onChange={() =>
-                    formik.setFieldValue(
-                      'requirements',
-                      noReqsChecked ? undefined : {},
-                    )
-                  }
-                  color="primary"
-                />
-              }
-              label={t('noEligibilityReqs').toUpperCase()}
-            />
-            <FormHelperText error>{formik.errors.requirements}</FormHelperText>
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikMultiSelect
-              disabled={noReqsChecked}
-              label={t('grades')}
-              id="requirements.grades"
-              labelStyle={labelStyle}
-              formik={formik}
-              options={GradeLevelInfo.values()}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikTextField
-              id="requirements.gpa"
-              type="number"
-              disabled={noReqsChecked}
-              formik={formik}
-              label={t('minGpa')}
-              labelStyle={labelStyle}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikAutocomplete
-              disabled={noReqsChecked}
-              label={t('schools')}
-              id="requirements.schools"
-              labelStyle={labelStyle}
-              options={allSchools.map(
-                ({ name, state }) => `${name} (${state})`,
-              )}
-              freeSolo
-              formik={formik}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikAutocomplete
-              disabled={noReqsChecked}
-              label={t('states')}
-              id="requirements.states"
-              labelStyle={labelStyle}
-              options={STATES.map((s) => s.abbr)}
-              getOptionLabel={(s) => State.toString(s)}
-              filterOptions={createFilterOptions({
-                stringify: (s) => State.toString(s),
-              })}
-              formik={formik}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikAutocomplete
-              disabled={noReqsChecked}
-              label={t('majors')}
-              id="requirements.majors"
-              labelStyle={labelStyle}
-              options={allMajors}
-              freeSolo
-              formik={formik}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <FormikMultiSelect
-              disabled={noReqsChecked}
-              label={t('ethnicity')}
-              id="requirements.ethnicities"
-              labelStyle={labelStyle}
-              formik={formik}
-              options={EthnicityInfo.values()}
-              placeholder={t('noRequirements')}
-            />
-          </Grid>
-        </Grid>
-      ),
-    },
-    [t('common:review')]: {
-      description: isDesktop ? t('reviewOnRight') : t('reviewBelow'),
-      content: !isDesktop && (
-        <ScholarshipCard
-          scholarship={{ data: formik.values }}
-          style="preview"
-        />
-      ),
-    },
-  };
-
-  function validationCheck() {
-    const noReqsGiven =
-      !formik.values.requirements ||
-      Object.values(formik.values.requirements).every(
-        (val) => (Array.isArray(val) && val.length === 0) || val === '',
-      );
-    // no requirements & no checkbox fails
-    if (activeStep == 1 && !noReqsChecked && noReqsGiven)
-      return validationT('checkboxValid');
-
-    return '';
-  }
-
-  const onLastStep = activeStep == Object.keys(stepperItems).length - 1;
-
   return (
-    <Box
-      sx={{
-        display: isDesktop ? 'flex' : 'block',
-        alignItems: 'flex-start',
-      }}>
-      <Paper
-        elevation={2}
-        sx={{
-          p: { xs: 2, sm: 3 },
-          width: isDesktop ? '50%' : '100%',
-          mr: 2,
-        }}>
-        <form onSubmit={formik.handleSubmit}>
-          <Stepper activeStep={activeStep} orientation="vertical">
-            {Object.entries(stepperItems).map(
-              ([label, { description, content }]) => (
-                <Step key={label}>
-                  <StepLabel>{label}</StepLabel>
-                  <StepContent>
-                    <Typography>{description}</Typography>
-                    <Box marginY={3}>{content}</Box>
-                    <Button
-                      disabled={activeStep === 0}
-                      onClick={() => setActiveStep((prevStep) => prevStep - 1)}>
-                      {t('common:actions.back')}
-                    </Button>
-                    <Button
-                      key={activeStep}
-                      variant="contained"
-                      color="primary"
-                      disabled={formik.isSubmitting}
-                      type={onLastStep ? 'submit' : 'button'}
-                      onClick={() => {
-                        if (onLastStep) return;
-                        formik.validateForm().then((errors) => {
-                          const checkboxError = validationCheck();
-                          if (checkboxError)
-                            errors = { ...errors, requirements: checkboxError };
-
-                          if (Object.keys(errors).length === 0)
-                            setActiveStep((prevStep) => prevStep + 1);
-
-                          return formik.setErrors(errors);
-                        });
-                      }}>
-                      {onLastStep
-                        ? t('common:actions.submit')
-                        : t('common:actions.next')}
-                    </Button>
-                    {submissionError && (
-                      <Alert
-                        severity="error"
-                        onClose={() => setSubmissionError(null)}>
-                        <AlertTitle>
-                          There was an error submitting your changes:
-                        </AlertTitle>
-                        {submissionError.toString()}
-                      </Alert>
-                    )}
-                  </StepContent>
-                </Step>
-              ),
-            )}
-          </Stepper>
-        </form>
-      </Paper>
-
-      <Box sx={{ width: '50%' }}>
-        {isDesktop && (
-          <ScholarshipCard
-            scholarship={{ data: formik.values }}
-            style="preview"
-          />
-        )}
-      </Box>
-    </Box>
+    <Grid container spacing={3}>
+      <Grid item sm={6} xs={12}>
+        <FormikTextField
+          label={`${t('scholarshipName')} *`}
+          id="name"
+          formik={formik}
+          labelStyle={labelStyle}
+        />
+      </Grid>
+      <Grid item sm={6} xs={12}>
+        <FormikTextField
+          label={t('organization')}
+          id="organization"
+          formik={formik}
+          labelStyle={labelStyle}
+        />
+      </Grid>
+      <Grid item sm={6} xs={12}>
+        <FormikTextField
+          label={`${t('scholarshipLink')} *`}
+          id="website"
+          formik={formik}
+          labelStyle={labelStyle}
+          placeholder="https://"
+          onBlur={(e) => {
+            // Automatically prepend https:// to the URL if the protocol is missing
+            if (!/https?:\/\//.test(e.target.value)) {
+              formik.setFieldValue('website', 'https://' + e.target.value);
+            }
+          }}
+        />
+      </Grid>
+      <Grid item sm={6}>
+        <DeadlineField
+          label={`${t('deadline')} *`}
+          labelStyle={labelStyle}
+          formik={formik}
+        />
+      </Grid>
+      <Grid item>
+        <ScholarshipAmountField formik={formik} labelStyle={labelStyle} />
+      </Grid>
+      <Grid item xs={12}>
+        <FormikTextField
+          label={`${t('description')} *`}
+          id="description"
+          labelStyle={labelStyle}
+          formik={formik}
+          minRows={8}
+        />
+      </Grid>
+      <Grid item sm={6} xs={12}>
+        <FormikAutocomplete
+          label={t('tags')}
+          id="tags"
+          labelStyle={labelStyle}
+          freeSolo
+          formik={formik}
+          options={[]}
+          onChange={(e, vals) => {
+            const newVals = new Set(
+              vals.map((v) => v.toLowerCase().replace(/\s+/g, '-')),
+            );
+            formik.setFieldValue('tags', Array.from(newVals));
+          }}
+          placeholder="E.g. athletics, daca, essay, stem, etc."
+        />
+      </Grid>
+    </Grid>
   );
 }


### PR DESCRIPTION
- Extract GeneralInfoStep into components/scholarship-form/GeneralInfoStep.tsx
- Extract EligibilityStep into components/scholarship-form/EligibilityStep.tsx
- Convert stepperItems from object-keyed-by-translation to a typed array
- Reduce ScholarshipForm.tsx from 410 lines to ~180 lines
- Move lint autofill logic into EligibilityStep where it belongs

<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

Fixes #

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Existing or new tests cover my changes.
- [ ] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
1.

## Screenshots

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- ATTACH screenshots for user visible changes. -->
