### PR TITLE
fix: don't override JAVA_HOME in emulators_exec.sh

### DIFF
--- a/scripts/emulators_exec.sh
+++ b/scripts/emulators_exec.sh
@@ -7,7 +7,8 @@ warn() {
   echo "${BOLD}${YELLOW}WARNING:${NORMAL} $1"
 }
 
-export JAVA_HOME="/opt/homebrew/opt/openjdk@21"
+# Only set JAVA_HOME if not already set (CI provides it via setup-java)
+export JAVA_HOME="${JAVA_HOME:-/opt/homebrew/opt/openjdk@21}"
 if lsof -i tcp:8080; then
   PID=$(lsof -t -i tcp:8080)
   warn "Firestore emulator may already be running (PID: $PID)!"


### PR DESCRIPTION
The hardcoded JAVA_HOME=/opt/homebrew/opt/openjdk@21 overrides the value set by actions/setup-java@v4 in CI, causing the Firebase emulator to not find Java on Ubuntu runners.

Use ${JAVA_HOME:-...} so CI's value is preserved while still falling back to the Homebrew path for local macOS development.

<!-- SUMMARIZE your changes in the Title above. Provide details here. -->

## Motivation and Context

<!-- EXPLAIN why this change is required. Link issues via "Fixes #" or "Helps with #". -->

Fixes #

## Types of changes

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] User visible change (users will notice UI or functional changes)

## How Has This Been Tested?

<!-- CHECK all the boxes that apply, replacing "[ ]" with "[x]". -->

- [ ] Existing or new tests cover my changes.
- [ ] Manually tested locally or on the Render PR Server.

## Previewing Changes

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- DETAIL steps to preview user visible changes on the Render PR server. -->
<!-- Tip: You can replace the first step with a direct link. -->

1. Click the `onrender.com` URL the **render `bot`** posted below.
1.

## Screenshots

<!-- DELETE THIS SECTION IF THERE ARE NO VISIBLE CHANGES. -->
<!-- ATTACH screenshots for user visible changes. -->
