### PR TITLE
fix: increase Firestore query page size from 10 to 50

### DIFF
--- a/src/models/Scholarships.ts
+++ b/src/models/Scholarships.ts
@@ -106,7 +106,7 @@ export interface FilterOptions {
   sortField?: string;
 }
 
-const queryLimit = 10;
+const queryLimit = 50;
 
 class Scholarships extends FirestoreCollection<ScholarshipData> {
   name = 'scholarships';


### PR DESCRIPTION
Reduces roundtrips 5x when client-side filtering discards results. Firestore reads are cheap ($0.06/100K) so 50/page is negligible.
