### PR TITLE
Replace react-helmet with useDocumentTitle() hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react-device-detect": "^2.0.0",
     "react-dom": "^19.2.4",
     "react-firebaseui": "^6.0.0",
-    "react-helmet": "^6.1.0",
     "react-i18next": "^16.5.4",
     "react-router-dom": "^7.13.0",
     "react-share": "^5.1.0",
@@ -63,7 +62,6 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@testing-library/dom": "^10.4.1",
-    "@types/react-helmet": "^6.1.11",
     "@typescript-eslint/eslint-plugin": "^8.55.0",
     "@typescript-eslint/parser": "^8.55.0",
     "@vitejs/plugin-react": "^5.1.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import './App.css';
 import React, { lazy, Suspense } from 'react';
-import { Helmet } from 'react-helmet';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import {
   CssBaseline,
@@ -12,7 +11,6 @@ import Footer from './components/Footer';
 import Home from './pages/PublicHome';
 import Header, { HeaderSkeleton } from './components/Header';
 import theme from './theme';
-import { BRAND_NAME } from './config/constants';
 import FirebaseProvider from './lib/FirebaseProvider';
 import ProtectedRoute from './components/ProtectedRoute';
 import { AuthProvider } from './lib/useAuth';
@@ -48,12 +46,6 @@ function App(): JSX.Element {
         <StyledEngineProvider injectFirst>
           <ThemeProvider theme={theme}>
             <CssBaseline />
-            <Helmet
-              titleTemplate={`%s | ${BRAND_NAME}`}
-              defaultTitle={
-                BRAND_NAME + ' | Scholarships for Undocumented Students'
-              }
-            />
             <AuthProvider>
               <ScholarshipsProvider>
                 <Router>

--- a/src/lib/useDocumentTitle.ts
+++ b/src/lib/useDocumentTitle.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+const BRAND_NAME = 'DreamScholars';
+const SUFFIX = ` | ${BRAND_NAME}`;
+const DEFAULT_TITLE = `${BRAND_NAME} | Scholarships for Undocumented Students`;
+
+/**
+ * Sets document.title with the brand suffix.
+ * Pass a title to set "Title | DreamScholars".
+ * Pass nothing or empty string to use the default title.
+ */
+export default function useDocumentTitle(title?: string): void {
+  useEffect(() => {
+    document.title = title ? `${title}${SUFFIX}` : DEFAULT_TITLE;
+    return () => {
+      document.title = DEFAULT_TITLE;
+    };
+  }, [title]);
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Helmet } from 'react-helmet';
+import useDocumentTitle from '../lib/useDocumentTitle';
 import {
   Container,
   Grid,
@@ -15,6 +15,7 @@ import LookingForScholarshipsBanner from '../components/LookingForScholarshipsBa
 
 export default function About(): JSX.Element {
   const { t } = useTranslation('about');
+  useDocumentTitle(t('titleTag'));
 
   const team = [
     {
@@ -51,10 +52,6 @@ export default function About(): JSX.Element {
 
   return (
     <Container sx={{ p: 2 }}>
-      <Helmet>
-        <title>{t('titleTag')}</title>
-      </Helmet>
-
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
           <Typography component="h2" variant="button" gutterBottom>

--- a/src/pages/AddScholarship.tsx
+++ b/src/pages/AddScholarship.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Helmet } from 'react-helmet';
+import useDocumentTitle from '../lib/useDocumentTitle';
 import { Container, Typography, Grid, Box } from '@mui/material';
 import ScholarshipForm from '../components/ScholarshipForm';
 import Scholarships from '../models/Scholarships';
@@ -7,13 +7,10 @@ import { useTranslation } from 'react-i18next';
 
 function AddScholarship(): JSX.Element {
   const { t } = useTranslation('addScholarship');
+  useDocumentTitle(t('titleTag'));
 
   return (
     <Box sx={{ p: 2 }}>
-      <Helmet>
-        <title>{t('titleTag')}</title>
-      </Helmet>
-
       <Container maxWidth="lg" sx={{ p: 2 }}>
         <Grid container spacing={2}>
           <Grid

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Helmet } from 'react-helmet';
+import useDocumentTitle from '../lib/useDocumentTitle';
 import { Link } from 'react-router-dom';
 import {
   featureRequest,
@@ -13,13 +13,10 @@ import { useTranslation, Trans } from 'react-i18next';
 
 function Contact(): JSX.Element {
   const { t } = useTranslation('contact');
+  useDocumentTitle(t('titleTag'));
 
   return (
     <Container sx={{ p: 2 }}>
-      <Helmet>
-        <title>{t('titleTag')}</title>
-      </Helmet>
-
       <Typography variant="h4" align="center" gutterBottom>
         {t('contactUs')}
       </Typography>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useState } from 'react';
-import Helmet from 'react-helmet';
+import useDocumentTitle from '../lib/useDocumentTitle';
 import { AddCircle as AddIcon, Inbox as InboxIcon } from '@mui/icons-material';
 import { Link, useLocation, useNavigationType } from 'react-router-dom';
 import {
@@ -23,6 +23,7 @@ type LocationProps = {
 
 export default function Dashboard(): JSX.Element {
   const { t } = useTranslation(['dashboard', 'common']);
+  useDocumentTitle(t('common:dashboard'));
   const { currentUser: user } = useAuth();
   const location = useLocation() as LocationProps;
 
@@ -31,10 +32,6 @@ export default function Dashboard(): JSX.Element {
   const [showAlert, setShowAlert] = useState(true);
   return (
     <Container sx={{ p: 2 }}>
-      <Helmet>
-        <title>{t('common:dashboard')}</title>
-      </Helmet>
-
       {alertMessage && navType === 'PUSH' && (
         <Collapse in={showAlert}>
           <Alert severity="success" onClose={() => setShowAlert(false)}>

--- a/src/pages/EditScholarship.tsx
+++ b/src/pages/EditScholarship.tsx
@@ -15,13 +15,14 @@ import {
 } from '@mui/material';
 import ScholarshipForm from '../components/ScholarshipForm';
 import Scholarships from '../models/Scholarships';
-import { Helmet } from 'react-helmet';
+import useDocumentTitle from '../lib/useDocumentTitle';
 import useAuth from '../lib/useAuth';
 import ScholarshipsContext from '../models/ScholarshipsContext';
 import ScholarshipData from '../types/ScholarshipData';
 import Model from '../models/base/Model';
 
 function EditScholarship(): JSX.Element {
+  useDocumentTitle('Edit a scholarship');
   const { id } = useParams();
   const [scholarship, setScholarship] = useState<
     Model<ScholarshipData> | undefined
@@ -87,10 +88,6 @@ function EditScholarship(): JSX.Element {
 
   return (
     <Box sx={{ p: 2 }}>
-      <Helmet>
-        <title>Edit a scholarship</title>
-      </Helmet>
-
       <>
         <Container maxWidth="xl">
           <ScholarshipForm scholarship={scholarship} />

--- a/src/pages/ListScholarships.tsx
+++ b/src/pages/ListScholarships.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet';
+import useDocumentTitle from '../lib/useDocumentTitle';
 import { useTranslation } from 'react-i18next';
 import {
   Box,
@@ -28,6 +28,7 @@ const drawerWidth = 360;
 
 function ListScholarships(): JSX.Element {
   const { t } = useTranslation('listScholarships');
+  useDocumentTitle(t('titleTag'));
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   const isDesktop = useMediaQuery((theme: Theme) => theme.breakpoints.up('md'));
@@ -85,9 +86,6 @@ function ListScholarships(): JSX.Element {
 
   return (
     <Box sx={{ display: 'flex' }}>
-      <Helmet>
-        <title>{t('titleTag')}</title>
-      </Helmet>
       <Drawer
         sx={{
           flexShrink: 0,

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,8 +1,9 @@
 import { Container, Link, Typography } from '@mui/material';
-import { Helmet } from 'react-helmet';
+import useDocumentTitle from '../lib/useDocumentTitle';
 import { genMailToLink } from '../lib/mail';
 
 export default function Privacy(): JSX.Element {
+  useDocumentTitle('Privacy Notice');
   const contactLink = (
     <Link href={genMailToLink({ subject: 'Privacy Notice' })}>
       info@dreamscholars.org
@@ -11,9 +12,6 @@ export default function Privacy(): JSX.Element {
 
   return (
     <Container maxWidth="md" sx={{ p: 2 }}>
-      <Helmet>
-        <title>Privacy Notice</title>
-      </Helmet>
       <Typography variant="h3" gutterBottom>
         Privacy Notice
       </Typography>

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,8 +1,9 @@
 import { Container, Link, Typography } from '@mui/material';
-import { Helmet } from 'react-helmet';
+import useDocumentTitle from '../lib/useDocumentTitle';
 import { genMailToLink } from '../lib/mail';
 
 export default function Terms(): JSX.Element {
+  useDocumentTitle('Terms and Conditions');
   const contactLink = (
     <Link href={genMailToLink({ subject: 'Terms of Use' })}>
       info@dreamscholars.org
@@ -11,9 +12,6 @@ export default function Terms(): JSX.Element {
 
   return (
     <Container maxWidth="md" sx={{ p: 2 }}>
-      <Helmet>
-        <title>Terms and Conditions</title>
-      </Helmet>
       <Typography variant="h3" gutterBottom>
         Terms of Use
       </Typography>

--- a/src/pages/ViewScholarship.test.tsx
+++ b/src/pages/ViewScholarship.test.tsx
@@ -1,6 +1,5 @@
 import MutationObserver from 'mutation-observer';
 import React, { Suspense } from 'react';
-import Helmet from 'react-helmet';
 import { render, screen, waitFor } from '@testing-library/react';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -77,7 +76,7 @@ test('renders passed in scholarship details', async () => {
     screen.getByText(data.deadline.toLocaleDateString()),
   ).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /Apply/i })).toBeInTheDocument();
-  expect(Helmet.peek().title).toBe(data.name);
+  expect(document.title).toBe(data.name + ' | DreamScholars');
 });
 
 test('renders scholarship details', async () => {
@@ -113,7 +112,7 @@ test('renders scholarship details', async () => {
     screen.getByText(data.deadline.toLocaleDateString()),
   ).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /Apply/i })).toBeInTheDocument();
-  expect(Helmet.peek().title).toBe(data.name);
+  expect(document.title).toBe(data.name + ' | DreamScholars');
   data.requirements.states
     .map(State.toString)
     .forEach((s) => expect(screen.getByText(s)).toBeInTheDocument());

--- a/src/pages/ViewScholarship.tsx
+++ b/src/pages/ViewScholarship.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet';
+import useDocumentTitle from '../lib/useDocumentTitle';
 import { Container, Typography, Box, Collapse } from '@mui/material';
 import Scholarships from '../models/Scholarships';
 import ScholarshipCard from '../components/ScholarshipCard';
@@ -25,6 +25,7 @@ export default function ViewScholarship(): JSX.Element {
     scholarships.find((s) => s.id === id) ||
       (location?.state as LocationState)?.scholarship,
   );
+  useDocumentTitle(scholarship?.data?.name);
   const [error, setError] = useState<Error>();
   const loading = !error && (!scholarship || scholarship.id !== id);
   const prevPath = (location?.state as LocationState)?.prevPath;
@@ -60,13 +61,9 @@ export default function ViewScholarship(): JSX.Element {
     );
   }
 
-  const { name, dateAdded, lastModified } = scholarship.data;
+  const { dateAdded, lastModified } = scholarship.data;
   return (
     <Container maxWidth="md">
-      <Helmet>
-        <title>{name}</title>
-      </Helmet>
-
       {justEdited && navType === 'PUSH' && (
         <Collapse in={showAlert}>
           <Alert

--- a/yarn.lock
+++ b/yarn.lock
@@ -2270,19 +2270,12 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.2.3.tgz#c1e305d15a52a3e508d54dca770d202cb63abf2c"
   integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
 
-"@types/react-helmet@^6.1.11":
-  version "6.1.11"
-  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-6.1.11.tgz#8cafcafff38f75361f451563ba7b406b0c5d3907"
-  integrity sha512-0QcdGLddTERotCXo3VFlUSWO3ztraw8nZ6e3zJSgG7apwV5xt+pJUS8ewPBqT4NYB1optGLprNQzFleIY84u/g==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-transition-group@^4.4.11", "@types/react-transition-group@^4.4.12":
   version "4.4.12"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.12.tgz#b5d76568485b02a307238270bfe96cb51ee2a044"
   integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
 
-"@types/react@*", "@types/react@^18.2.74":
+"@types/react@^18.2.74":
   version "18.3.27"
   resolved "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz"
   integrity sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==
@@ -8038,7 +8031,7 @@ promise-retry@^2.0.1:
     err-code "^2.0.2"
     retry "^0.12.0"
 
-prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.6.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8239,27 +8232,12 @@ react-fast-compare@^2.0.1:
   resolved "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-fast-compare@^3.1.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
-  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
-
 react-firebaseui@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/react-firebaseui/-/react-firebaseui-6.0.0.tgz"
   integrity sha512-VzLMiW7DBZCsW/qpP9nky/pPlAoIjDxA2Qyc+QAPf+RjelIkvPPiCBXR2aAz+Upy+ujrx6pYDXj547DW5uC4ww==
   dependencies:
     firebaseui "^6.0.0"
-
-react-helmet@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz"
-  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
-  dependencies:
-    object-assign "^4.1.1"
-    prop-types "^15.7.2"
-    react-fast-compare "^3.1.1"
-    react-side-effect "^2.1.0"
 
 react-i18next@^16.5.4:
   version "16.5.4"
@@ -8312,11 +8290,6 @@ react-share@^5.1.0:
   dependencies:
     classnames "^2.3.2"
     jsonp "^0.2.1"
-
-react-side-effect@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.2.tgz#dc6345b9e8f9906dc2eeb68700b615e0b4fe752a"
-  integrity sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==
 
 react-transition-group@^4.4.5:
   version "4.4.5"


### PR DESCRIPTION
This eliminates the `react-helmet` dependency entirely (and its `@types/react-helmet` devDep), removes a deprecated library, and is fully compatible with React 19.